### PR TITLE
Add Docker support with multi-arch GHCR publishing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+bin/
+cmd/**/dist/
+node_modules/
+.git/
+*.jpg
+*.jpeg
+*.png
+*.mp4

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@ bin/
 cmd/**/dist/
 node_modules/
 .git/
+.DS_Store
+*.exe
 *.jpg
 *.jpeg
 *.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,16 +119,32 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: git checkout ${{ inputs.tag }}
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.IMAGE }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=raw,value=latest
+      - name: Resolve Docker tags
+        id: docker-tags
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="${{ inputs.tag }}"
+          else
+            release_tag="${{ github.ref_name }}"
+          fi
+          version="${release_tag#v}"
+          minor="${version%.*}"
+          major="${version%%.*}"
+
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE}:${version}"
+            echo "${IMAGE}:${minor}"
+            if [ "$major" != "0" ]; then
+              echo "${IMAGE}:${major}"
+            fi
+            echo "${IMAGE}:latest"
+            echo "EOF"
+            echo "labels<<EOF"
+            echo "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+            echo "org.opencontainers.image.version=${version}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -149,7 +165,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.docker-tags.outputs.tags }}
+          labels: ${{ steps.docker-tags.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,18 +13,22 @@ on:
 
 permissions:
   contents: write
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -37,7 +41,7 @@ jobs:
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest
@@ -103,3 +107,49 @@ jobs:
             --repo steipete/homebrew-tap \
             --exit-status \
             --interval 10
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Checkout release tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: git checkout ${{ inputs.tag }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.24-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /camsnap ./cmd/camsnap
+
+FROM alpine:3.23
+RUN apk add --no-cache ffmpeg
+RUN adduser -D -h /home/camsnap camsnap
+USER camsnap
+ENV XDG_CONFIG_HOME=/config
+VOLUME ["/config", "/output"]
+WORKDIR /output
+COPY --from=build /camsnap /usr/local/bin/camsnap
+ENTRYPOINT ["camsnap"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /camsnap ./cmd/camsnap
 
 FROM alpine:3.23
 RUN apk add --no-cache ffmpeg
-RUN adduser -D -h /home/camsnap camsnap
+RUN adduser -D -h /home/camsnap camsnap \
+ && mkdir -p /config /output \
+ && chown camsnap:camsnap /config /output
 USER camsnap
 ENV XDG_CONFIG_HOME=/config
 VOLUME ["/config", "/output"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 - Homebrew (installs `ffmpeg` automatically): `brew install steipete/tap/camsnap`
 - Requirements for source run: Go 1.22+ and `ffmpeg` on PATH.
 - Run in-place: `go run ./cmd/camsnap --help`
+- Run in Docker: `docker run --rm ghcr.io/steipete/camsnap --help`
+  Mount volumes for persistent config and output:
+  ```sh
+  docker run --rm -v camsnap-config:/config -v "$PWD":/output \
+    ghcr.io/steipete/camsnap snap kitchen --out shot.jpg
+  ```
 - Camera name may be positional (e.g., `camsnap snap kitchen ...`).
 - If `--out` is omitted, snap/clip writes to a temp file and prints the path.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - Homebrew (installs `ffmpeg` automatically): `brew install steipete/tap/camsnap`
 - Requirements for source run: Go 1.22+ and `ffmpeg` on PATH.
 - Run in-place: `go run ./cmd/camsnap --help`
-- Run in Docker: `docker run --rm ghcr.io/steipete/camsnap --help`
+- Run in Docker: `docker run --rm ghcr.io/steipete/camsnap --help`  
   Mount volumes for persistent config and output:
   ```sh
   docker run --rm -v camsnap-config:/config -v "$PWD":/output \


### PR DESCRIPTION
Providing a Docker image would allow users to use this anywhere without installing Go on their machines. 🙂 

- Add multi-stage Dockerfile (Alpine + ffmpeg, non-root) with `/config` and `/output` volumes
- Integrate Docker build-and-push into the release workflow (linux/amd64 + linux/arm64, GHCR)
- Add `.dockerignore` and update `README.md` with Docker usage

## Usage
``` sh
docker run --rm -v camsnap-config:/config -v "$PWD":/output \
  ghcr.io/steipete/camsnap snap kitchen --out shot.jpg
```