### PR TITLE
feat: local webcam capture (avfoundation/v4l2) with devices command and TCC-aware errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 0.2.3 - Unreleased
+- Add first-class local webcam capture through macOS AVFoundation and Linux v4l2, including device enumeration, warm snapshot capture, video-only clips, motion watch, doctor probes, and TCC-aware errors.
+- Fix capture commands ignoring per-camera defaults when their flags had non-empty application defaults (PR #9).
 - Redact RTSP credentials from ffmpeg failures, restore private camera-config permissions on rewrite, and safely finalize gortsplib frame buffers.
 - Migrate the gortsplib RTSP backend to the maintained v5 release, adopt Go 1.26, and refresh runtime dependencies.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# 📸 camsnap — One command to grab frames, clips, or motion alerts from your cams (RTSP/ONVIF).
+# 📸 camsnap — One command to grab frames, clips, or motion alerts from RTSP/ONVIF cameras and local webcams.
 
 ## Install / Run
 - Homebrew (installs `ffmpeg` automatically): `brew install steipete/tap/camsnap`
-- Requirements for source run: Go 1.26+ and `ffmpeg` on PATH.
+- Requirements for source run: Go 1.26+ and `ffmpeg` on PATH. Local webcams use AVFoundation on macOS and v4l2 on Linux; Windows is not supported.
 - Run in-place: `go run ./cmd/camsnap --help`
 - Run in Docker: `docker run --rm ghcr.io/steipete/camsnap --help`  
   Mount volumes for persistent config and output:
@@ -65,6 +65,31 @@ go run ./cmd/camsnap discover --info
 go run ./cmd/camsnap doctor --probe --rtsp-transport udp
 ```
 
+## Local webcams
+
+List the local video inputs that ffmpeg can see, then either save one in the camera config or use it ad hoc. On macOS the device can be an AVFoundation index or name; on Linux use a `/dev/videoN` path.
+
+```sh
+camsnap devices
+camsnap devices --json
+
+# Save a macOS camera, then use the same snap/clip/watch commands as RTSP cameras.
+camsnap add --name mbp --protocol local --device 0
+camsnap snap mbp --out shot.jpg
+camsnap clip mbp --dur 5s --out clip.mp4
+camsnap watch mbp --threshold 0.2 --action 'touch /tmp/motion'
+
+# Or capture without adding a camera first.
+camsnap snap --device 0 --framerate 30 --video-size 1280x720 --warmup 1s --out shot.jpg
+camsnap clip --device /dev/video0 --dur 5s --out clip.mp4
+```
+
+Local snapshots warm up the camera before keeping the final JPEG so auto-exposure can settle. Local clips are video-only for now: camsnap encodes H.264 and does not request microphone access.
+
+On macOS, Camera permission belongs to the terminal or application that launches camsnap—not to the `camsnap` binary itself. Grant that launcher access in **System Settings → Privacy & Security → Camera**. An SSH session cannot display the macOS permission prompt; if access was previously denied, run `tccutil reset Camera` locally and retry from the launching terminal. Continuity Camera is listed only while the iPhone is nearby and unlocked.
+
+Direct local-device capture is not supported from the camsnap Docker image. Windows local webcams are also unsupported; RTSP cameras continue to work on both Docker and Windows builds.
+
 ## Tapo specifics
 - Enable “Third‑Party NVR/RTSP” and set a per‑camera account; disable Privacy Mode.
 - TC70 often needs `udp` + `stream2` + `gortsplib` and may require disabling Tapo Care/SD recording to free RTSP streams.
@@ -73,7 +98,7 @@ go run ./cmd/camsnap doctor --probe --rtsp-transport udp
 
 ## Behavior notes
 - Motion uses ffmpeg scene-change detection; actions can log JSON (`--json`).
-- Doctor classifies ffmpeg probe errors (auth vs network).
+- Doctor classifies ffmpeg probe errors (auth, network, local-device, and macOS Camera permission failures).
 - Per-camera defaults reduce flag noise for devices with quirks.
 
 ## Roadmap

--- a/internal/capture/args.go
+++ b/internal/capture/args.go
@@ -2,63 +2,104 @@ package capture
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
-// SnapArgs returns ffmpeg arguments for a single-frame capture.
-func SnapArgs(options Options, outputPath string) []string {
-	return []string{
-		"-y",
-		"-rtsp_transport", options.Transport,
-		"-i", options.URL,
-		"-frames:v", "1",
-		"-q:v", "2",
-		outputPath,
+// InputArgs returns source-specific ffmpeg input arguments.
+func InputArgs(options Options, goos string) ([]string, error) {
+	if options.Kind == KindRTSP {
+		return []string{"-rtsp_transport", options.Transport, "-i", options.URL}, nil
 	}
+
+	var args []string
+	switch goos {
+	case "darwin":
+		args = []string{"-f", "avfoundation", "-framerate", strconv.Itoa(options.Framerate)}
+	case "linux":
+		args = []string{"-f", "v4l2"}
+		if options.Framerate > 0 {
+			args = append(args, "-framerate", strconv.Itoa(options.Framerate))
+		}
+	default:
+		return nil, fmt.Errorf("local webcam capture is unsupported on %s", goos)
+	}
+	if options.VideoSize != "" {
+		args = append(args, "-video_size", options.VideoSize)
+	}
+	return append(args, "-i", options.Device), nil
+}
+
+// SnapArgs returns ffmpeg arguments for a single-frame capture.
+func SnapArgs(options Options, outputPath, goos string) ([]string, error) {
+	input, err := InputArgs(options, goos)
+	if err != nil {
+		return nil, err
+	}
+	args := append([]string{"-y"}, input...)
+	if options.Kind == KindLocal {
+		return append(args, "-t", formatDuration(options.Warmup), "-update", "1", "-q:v", "2", outputPath), nil
+	}
+	return append(args, "-frames:v", "1", "-q:v", "2", outputPath), nil
 }
 
 // ClipArgs returns ffmpeg arguments for a timed clip capture.
-func ClipArgs(options Options, duration time.Duration, outputPath string) []string {
-	args := []string{
-		"-y",
-		"-rtsp_transport", options.Transport,
-		"-i", options.URL,
-		"-t", fmt.Sprintf("%.0f", duration.Seconds()),
-		"-c:v", "copy",
+func ClipArgs(options Options, duration time.Duration, outputPath, goos string) ([]string, error) {
+	input, err := InputArgs(options, goos)
+	if err != nil {
+		return nil, err
 	}
+	args := append([]string{"-y"}, input...)
+	args = append(args, "-t", fmt.Sprintf("%.0f", duration.Seconds()))
+	if options.Kind == KindLocal {
+		return append(args,
+			"-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "veryfast",
+			"-movflags", "+faststart", "-an", outputPath,
+		), nil
+	}
+	args = append(args, "-c:v", "copy")
 	if options.NoAudio {
 		args = append(args, "-an")
 	} else {
 		args = append(args, "-c:a", options.AudioCodec)
 	}
-	return append(args, outputPath)
+	return append(args, outputPath), nil
 }
 
 // WatchArgs returns ffmpeg arguments for scene-change detection.
-func WatchArgs(options Options, threshold float64) []string {
-	return []string{
-		"-hide_banner",
-		"-loglevel", "info",
-		"-rtsp_transport", options.Transport,
-		"-i", options.URL,
+func WatchArgs(options Options, threshold float64, goos string) ([]string, error) {
+	input, err := InputArgs(options, goos)
+	if err != nil {
+		return nil, err
+	}
+	args := []string{
+		"-hide_banner", "-loglevel", "info",
+	}
+	args = append(args, input...)
+	return append(args,
 		"-an",
 		"-sn",
 		"-dn",
 		"-vf", fmt.Sprintf("select='gt(scene\\,%0.3f)',metadata=print", threshold),
 		"-f", "null",
 		"-",
-	}
+	), nil
 }
 
-// ProbeArgs returns ffmpeg arguments for a short RTSP health probe.
-func ProbeArgs(options Options) []string {
-	return []string{
-		"-hide_banner",
-		"-loglevel", "error",
-		"-rtsp_transport", options.Transport,
-		"-i", options.URL,
-		"-t", "1",
-		"-f", "null",
-		"-",
+// ProbeArgs returns ffmpeg arguments for a short health probe.
+func ProbeArgs(options Options, goos string) ([]string, error) {
+	input, err := InputArgs(options, goos)
+	if err != nil {
+		return nil, err
 	}
+	args := []string{"-hide_banner", "-loglevel", "error"}
+	args = append(args, input...)
+	if options.Kind == KindLocal {
+		return append(args, "-frames:v", "1", "-f", "null", "-"), nil
+	}
+	return append(args, "-t", "1", "-f", "null", "-"), nil
+}
+
+func formatDuration(duration time.Duration) string {
+	return strconv.FormatFloat(duration.Seconds(), 'f', -1, 64)
 }

--- a/internal/capture/args_test.go
+++ b/internal/capture/args_test.go
@@ -12,7 +12,11 @@ func TestSnapArgs(t *testing.T) {
 		"-y", "-rtsp_transport", "udp", "-i", "rtsp://camera.test/stream2",
 		"-frames:v", "1", "-q:v", "2", "shot.jpg",
 	}
-	if got := SnapArgs(options, "shot.jpg"); !reflect.DeepEqual(got, want) {
+	got, err := SnapArgs(options, "shot.jpg", "darwin")
+	if err != nil {
+		t.Fatalf("SnapArgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("SnapArgs = %#v, want %#v", got, want)
 	}
 }
@@ -43,7 +47,11 @@ func TestClipArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ClipArgs(tt.options, 5*time.Second, "clip.mp4"); !reflect.DeepEqual(got, tt.want) {
+			got, err := ClipArgs(tt.options, 5*time.Second, "clip.mp4", "darwin")
+			if err != nil {
+				t.Fatalf("ClipArgs: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("ClipArgs = %#v, want %#v", got, tt.want)
 			}
 		})
@@ -57,7 +65,11 @@ func TestWatchArgs(t *testing.T) {
 		"-i", "rtsp://camera.test/stream2", "-an", "-sn", "-dn",
 		"-vf", "select='gt(scene\\,0.200)',metadata=print", "-f", "null", "-",
 	}
-	if got := WatchArgs(options, 0.2); !reflect.DeepEqual(got, want) {
+	got, err := WatchArgs(options, 0.2, "darwin")
+	if err != nil {
+		t.Fatalf("WatchArgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("WatchArgs = %#v, want %#v", got, want)
 	}
 }
@@ -68,7 +80,86 @@ func TestProbeArgs(t *testing.T) {
 		"-hide_banner", "-loglevel", "error", "-rtsp_transport", "tcp",
 		"-i", "rtsp://camera.test/stream1", "-t", "1", "-f", "null", "-",
 	}
-	if got := ProbeArgs(options); !reflect.DeepEqual(got, want) {
+	got, err := ProbeArgs(options, "darwin")
+	if err != nil {
+		t.Fatalf("ProbeArgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("ProbeArgs = %#v, want %#v", got, want)
+	}
+}
+
+func TestLocalInputArgs(t *testing.T) {
+	options := Options{Kind: KindLocal, Device: "2", Framerate: 24, VideoSize: "1280x720"}
+	tests := []struct {
+		goos string
+		want []string
+	}{
+		{
+			goos: "darwin",
+			want: []string{"-f", "avfoundation", "-framerate", "24", "-video_size", "1280x720", "-i", "2"},
+		},
+		{
+			goos: "linux",
+			want: []string{"-f", "v4l2", "-framerate", "24", "-video_size", "1280x720", "-i", "2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			got, err := InputArgs(options, tt.goos)
+			if err != nil {
+				t.Fatalf("InputArgs: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("InputArgs = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalCommandArgs(t *testing.T) {
+	options := Options{Kind: KindLocal, Device: "0", Framerate: 30, VideoSize: "1920x1080", Warmup: 1500 * time.Millisecond}
+
+	snap, err := SnapArgs(options, "shot.jpg", "darwin")
+	if err != nil {
+		t.Fatalf("SnapArgs: %v", err)
+	}
+	wantSnap := []string{
+		"-y", "-f", "avfoundation", "-framerate", "30", "-video_size", "1920x1080", "-i", "0",
+		"-t", "1.5", "-update", "1", "-q:v", "2", "shot.jpg",
+	}
+	if !reflect.DeepEqual(snap, wantSnap) {
+		t.Fatalf("SnapArgs = %#v, want %#v", snap, wantSnap)
+	}
+
+	clip, err := ClipArgs(options, 5*time.Second, "clip.mp4", "linux")
+	if err != nil {
+		t.Fatalf("ClipArgs: %v", err)
+	}
+	wantClip := []string{
+		"-y", "-f", "v4l2", "-framerate", "30", "-video_size", "1920x1080", "-i", "0", "-t", "5",
+		"-c:v", "libx264", "-pix_fmt", "yuv420p", "-preset", "veryfast", "-movflags", "+faststart", "-an", "clip.mp4",
+	}
+	if !reflect.DeepEqual(clip, wantClip) {
+		t.Fatalf("ClipArgs = %#v, want %#v", clip, wantClip)
+	}
+
+	watch, err := WatchArgs(options, 0.2, "darwin")
+	if err != nil {
+		t.Fatalf("WatchArgs: %v", err)
+	}
+	wantWatch := []string{
+		"-hide_banner", "-loglevel", "info", "-f", "avfoundation", "-framerate", "30", "-video_size", "1920x1080", "-i", "0",
+		"-an", "-sn", "-dn", "-vf", "select='gt(scene\\,0.200)',metadata=print", "-f", "null", "-",
+	}
+	if !reflect.DeepEqual(watch, wantWatch) {
+		t.Fatalf("WatchArgs = %#v, want %#v", watch, wantWatch)
+	}
+}
+
+func TestInputArgsRejectsUnsupportedOS(t *testing.T) {
+	_, err := InputArgs(Options{Kind: KindLocal, Device: "camera", Framerate: 30}, "windows")
+	if err == nil || err.Error() != "local webcam capture is unsupported on windows" {
+		t.Fatalf("InputArgs error = %v", err)
 	}
 }

--- a/internal/capture/resolve.go
+++ b/internal/capture/resolve.go
@@ -4,6 +4,7 @@ package capture
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/steipete/camsnap/internal/config"
 	"github.com/steipete/camsnap/internal/rtsp"
@@ -13,6 +14,18 @@ const (
 	defaultTransport  = "tcp"
 	defaultClient     = "ffmpeg"
 	defaultAudioCodec = "aac"
+	defaultFramerate  = 30
+	defaultWarmup     = time.Second
+)
+
+// Kind identifies the source feeding a capture operation.
+type Kind uint8
+
+const (
+	// KindRTSP captures from a network RTSP source.
+	KindRTSP Kind = iota
+	// KindLocal captures from an operating-system video device.
+	KindLocal
 )
 
 // Overrides contains only flag values explicitly supplied by the user.
@@ -22,12 +35,18 @@ type Overrides struct {
 	Stream     *string
 	Client     *string
 	Path       *string
+	RTSPAuth   *string
 	NoAudio    *bool
 	AudioCodec *string
+	Device     *string
+	Framerate  *int
+	VideoSize  *string
+	Warmup     *time.Duration
 }
 
 // Options is the fully resolved capture configuration consumed by arg builders.
 type Options struct {
+	Kind       Kind
 	URL        string
 	Transport  string
 	Stream     string
@@ -35,10 +54,20 @@ type Options struct {
 	Path       string
 	NoAudio    bool
 	AudioCodec string
+	Device     string
+	Framerate  int
+	VideoSize  string
+	Warmup     time.Duration
 }
 
 // Resolve applies explicit flag, camera config, and application defaults in order.
 func Resolve(cam config.Camera, overrides Overrides) (Options, error) {
+	if strings.EqualFold(cam.Protocol, "local") {
+		return resolveLocal(cam, overrides)
+	}
+	if overrides.Device != nil || overrides.Framerate != nil || overrides.VideoSize != nil || overrides.Warmup != nil {
+		return Options{}, fmt.Errorf("--device, --framerate, --video-size, and --warmup are only valid for local cameras")
+	}
 	if nonEmpty(overrides.Stream) && nonEmpty(overrides.Path) {
 		return Options{}, fmt.Errorf("use --path for custom RTSP token URLs; omit --stream")
 	}
@@ -70,6 +99,7 @@ func Resolve(cam config.Camera, overrides Overrides) (Options, error) {
 	}
 
 	return Options{
+		Kind:       KindRTSP,
 		URL:        url,
 		Transport:  transport,
 		Stream:     stream,
@@ -77,6 +107,34 @@ func Resolve(cam config.Camera, overrides Overrides) (Options, error) {
 		Path:       path,
 		NoAudio:    boolValue(overrides.NoAudio, cam.NoAudio),
 		AudioCodec: stringValue(overrides.AudioCodec, cam.AudioCodec, defaultAudioCodec),
+	}, nil
+}
+
+func resolveLocal(cam config.Camera, overrides Overrides) (Options, error) {
+	if overrides.Transport != nil || overrides.Stream != nil || overrides.Client != nil || overrides.Path != nil || overrides.RTSPAuth != nil || overrides.NoAudio != nil || overrides.AudioCodec != nil {
+		return Options{}, fmt.Errorf("RTSP and audio flags are not valid for local cameras")
+	}
+
+	device := stringValue(overrides.Device, cam.Device, "")
+	if device == "" {
+		return Options{}, fmt.Errorf("local camera requires --device or a configured device")
+	}
+	framerate := intValue(overrides.Framerate, defaultFramerate)
+	if framerate <= 0 {
+		return Options{}, fmt.Errorf("--framerate must be > 0")
+	}
+	warmup := durationValue(overrides.Warmup, defaultWarmup)
+	if warmup <= 0 {
+		return Options{}, fmt.Errorf("--warmup must be > 0")
+	}
+
+	return Options{
+		Kind:      KindLocal,
+		Device:    device,
+		Framerate: framerate,
+		VideoSize: stringValue(overrides.VideoSize, "", ""),
+		Warmup:    warmup,
+		NoAudio:   true,
 	}, nil
 }
 
@@ -99,4 +157,18 @@ func boolValue(explicit *bool, cameraValue bool) bool {
 		return *explicit
 	}
 	return cameraValue
+}
+
+func intValue(explicit *int, defaultValue int) int {
+	if explicit != nil {
+		return *explicit
+	}
+	return defaultValue
+}
+
+func durationValue(explicit *time.Duration, defaultValue time.Duration) time.Duration {
+	if explicit != nil {
+		return *explicit
+	}
+	return defaultValue
 }

--- a/internal/capture/resolve_test.go
+++ b/internal/capture/resolve_test.go
@@ -1,7 +1,9 @@
 package capture
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/steipete/camsnap/internal/config"
 )
@@ -37,6 +39,61 @@ func TestResolvePrecedence(t *testing.T) {
 	}
 	if want := "rtsp://192.0.2.10:554/stream3"; got.URL != want {
 		t.Fatalf("URL = %q, want %q", got.URL, want)
+	}
+}
+
+func TestResolveLocalDefaultsAndOverrides(t *testing.T) {
+	framerate := 60
+	videoSize := "1920x1080"
+	warmup := 2 * time.Second
+	got, err := Resolve(config.Camera{Protocol: "local", Device: "0"}, Overrides{
+		Framerate: &framerate,
+		VideoSize: &videoSize,
+		Warmup:    &warmup,
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	want := Options{
+		Kind: KindLocal, Device: "0", Framerate: 60, VideoSize: "1920x1080", Warmup: 2 * time.Second, NoAudio: true,
+	}
+	if got != want {
+		t.Fatalf("Resolve = %#v, want %#v", got, want)
+	}
+
+	got, err = Resolve(config.Camera{Protocol: "LOCAL", Device: "FaceTime HD Camera"}, Overrides{})
+	if err != nil {
+		t.Fatalf("Resolve defaults: %v", err)
+	}
+	if got.Framerate != 30 || got.Warmup != time.Second || got.Device != "FaceTime HD Camera" {
+		t.Fatalf("local defaults not applied: %#v", got)
+	}
+}
+
+func TestResolveLocalValidation(t *testing.T) {
+	tcp := "tcp"
+	device := "0"
+	zero := 0
+	zeroDuration := time.Duration(0)
+	tests := []struct {
+		name      string
+		cam       config.Camera
+		overrides Overrides
+		contains  string
+	}{
+		{name: "missing device", cam: config.Camera{Protocol: "local"}, contains: "requires --device"},
+		{name: "RTSP flag", cam: config.Camera{Protocol: "local", Device: "0"}, overrides: Overrides{Transport: &tcp}, contains: "RTSP and audio flags"},
+		{name: "local flag on RTSP", cam: config.Camera{Host: "192.0.2.1"}, overrides: Overrides{Device: &device}, contains: "only valid for local cameras"},
+		{name: "zero framerate", cam: config.Camera{Protocol: "local", Device: "0"}, overrides: Overrides{Framerate: &zero}, contains: "--framerate must be > 0"},
+		{name: "zero warmup", cam: config.Camera{Protocol: "local", Device: "0"}, overrides: Overrides{Warmup: &zeroDuration}, contains: "--warmup must be > 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Resolve(tt.cam, tt.overrides)
+			if err == nil || !strings.Contains(err.Error(), tt.contains) {
+				t.Fatalf("Resolve error = %v, want substring %q", err, tt.contains)
+			}
+		})
 	}
 }
 

--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/camsnap/internal/config"
@@ -15,14 +16,33 @@ func newAddCmd() *cobra.Command {
 		Use:   "add",
 		Short: "Add or update a camera",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if cam.Name == "" || cam.Host == "" {
-				return fmt.Errorf("name and host are required")
+			cam.Protocol = strings.ToLower(cam.Protocol)
+			if cam.Name == "" {
+				return fmt.Errorf("name is required")
 			}
-			if cam.Port == 0 {
-				cam.Port = 554
-			}
-			if cam.Protocol == "" {
-				cam.Protocol = "rtsp"
+			switch cam.Protocol {
+			case "local":
+				if cam.Device == "" {
+					return fmt.Errorf("--device is required for protocol local")
+				}
+				for _, flag := range []string{"host", "port", "user", "pass", "path", "rtsp-transport", "stream", "rtsp-client", "no-audio", "audio-codec"} {
+					if cmd.Flags().Changed(flag) {
+						return fmt.Errorf("--%s is not valid for protocol local", flag)
+					}
+				}
+				cam.Port = 0
+			case "rtsp", "rtsps":
+				if cam.Host == "" {
+					return fmt.Errorf("name and host are required")
+				}
+				if cmd.Flags().Changed("device") {
+					return fmt.Errorf("--device is only valid for protocol local")
+				}
+				if cam.Port == 0 {
+					cam.Port = 554
+				}
+			default:
+				return fmt.Errorf("invalid --protocol (use rtsp|rtsps|local)")
 			}
 
 			cfgFlag, err := configPathFlag(cmd)
@@ -49,9 +69,10 @@ func newAddCmd() *cobra.Command {
 	cmd.Flags().StringVar(&cam.Name, "name", "", "Camera name (unique)")
 	cmd.Flags().StringVar(&cam.Host, "host", "", "Camera host or IP")
 	cmd.Flags().IntVar(&cam.Port, "port", 554, "Camera port (default 554)")
-	cmd.Flags().StringVar(&cam.Protocol, "protocol", "rtsp", "Protocol (rtsp or rtsps)")
+	cmd.Flags().StringVar(&cam.Protocol, "protocol", "rtsp", "Protocol (rtsp, rtsps, or local)")
 	cmd.Flags().StringVar(&cam.Username, "user", "", "Camera username")
 	cmd.Flags().StringVar(&cam.Password, "pass", "", "Camera password")
+	cmd.Flags().StringVar(&cam.Device, "device", "", "Local video device index, name, or /dev/videoN path")
 	cmd.Flags().StringVar(&cam.Path, "path", "", "Explicit RTSP path (e.g., /Bfy... token from UniFi Protect)")
 	cmd.Flags().StringVar(&cam.RTSPTransport, "rtsp-transport", "", "Preferred RTSP transport for this camera (tcp|udp)")
 	cmd.Flags().StringVar(&cam.Stream, "stream", "", "Default RTSP stream path (stream1 or stream2)")

--- a/internal/cli/clip.go
+++ b/internal/cli/clip.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -22,22 +23,43 @@ func newClipCmd() *cobra.Command {
 	var noAudio bool
 	var audioCodec string
 	var path string
+	var device string
+	var framerate int
+	var videoSize string
 
 	cmd := &cobra.Command{
 		Use:   "clip",
 		Short: "Record a short clip to a file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cameraName == "" && len(args) > 0 {
-				cameraName = args[0]
-			}
-			if cameraName == "" {
-				return fmt.Errorf("--camera is required")
-			}
 			if duration <= 0 {
 				return fmt.Errorf("--dur must be > 0")
 			}
 			if !mediaexec.HasBinary("ffmpeg") {
 				return fmt.Errorf("ffmpeg not found in PATH")
+			}
+			cam, selectedName, err := selectCaptureCamera(cmd, args, cameraName, device)
+			if err != nil {
+				return err
+			}
+			cameraName = selectedName
+			options, err := capture.Resolve(cam, (captureFlagValues{
+				transport:  transport,
+				stream:     stream,
+				path:       path,
+				rtspAuth:   authMode,
+				noAudio:    noAudio,
+				audioCodec: audioCodec,
+				device:     device,
+				framerate:  framerate,
+				videoSize:  videoSize,
+			}).overrides(cmd))
+			if err != nil {
+				return err
+			}
+			if options.Kind == capture.KindRTSP {
+				if _, ok := parseRTSPAuth(authMode); !ok {
+					return fmt.Errorf("invalid --rtsp-auth (use auto|basic|digest)")
+				}
 			}
 			if outPath == "" {
 				tmp, err := os.CreateTemp("", "camsnap-*.mp4")
@@ -51,37 +73,16 @@ func newClipCmd() *cobra.Command {
 				cmd.Printf("No --out provided, writing clip to %s\n", outPath)
 			}
 
-			cfgFlag, err := configPathFlag(cmd)
-			if err != nil {
-				return err
-			}
-			cfg, _, err := loadConfig(cfgFlag)
-			if err != nil {
-				return err
-			}
-			cam, ok := findCamera(cfg, cameraName)
-			if !ok {
-				return fmt.Errorf("camera %q not found", cameraName)
-			}
-
-			if _, ok := parseRTSPAuth(authMode); !ok {
-				return fmt.Errorf("invalid --rtsp-auth (use auto|basic|digest)")
-			}
-			options, err := capture.Resolve(cam, (captureFlagValues{
-				transport:  transport,
-				stream:     stream,
-				path:       path,
-				noAudio:    noAudio,
-				audioCodec: audioCodec,
-			}).overrides(cmd))
-			if err != nil {
-				return err
-			}
-
 			ctx, cancel := mediaexec.WithTimeout(context.Background(), timeout)
 			defer cancel()
+			if options.Kind == capture.KindLocal {
+				return runLocalCapture(ctx, localCaptureRequest{operation: localClip, options: options, output: outPath, duration: duration})
+			}
 
-			ffArgs := capture.ClipArgs(options, duration, outPath)
+			ffArgs, err := capture.ClipArgs(options, duration, outPath, runtime.GOOS)
+			if err != nil {
+				return err
+			}
 			return mediaexec.RunFFmpeg(ctx, ffArgs...)
 		},
 	}
@@ -96,6 +97,9 @@ func newClipCmd() *cobra.Command {
 	cmd.Flags().StringVar(&path, "path", "", "Custom RTSP path (overrides --stream), e.g., /Bfy... from UniFi Protect")
 	cmd.Flags().BoolVar(&noAudio, "no-audio", false, "Drop audio track")
 	cmd.Flags().StringVar(&audioCodec, "audio-codec", "", "Audio codec (default aac); ignored if --no-audio")
+	cmd.Flags().StringVar(&device, "device", "", "Local video device index, name, or /dev/videoN path")
+	cmd.Flags().IntVar(&framerate, "framerate", 30, "Local capture framerate")
+	cmd.Flags().StringVar(&videoSize, "video-size", "", "Local capture size (e.g., 1280x720)")
 
 	return cmd
 }

--- a/internal/cli/command_integration_test.go
+++ b/internal/cli/command_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -31,6 +32,98 @@ func TestAddAndList(t *testing.T) {
 	}
 	if !bytes.Contains(buf.Bytes(), []byte("t1")) {
 		t.Fatalf("expected camera name in list output, got: %s", buf.String())
+	}
+}
+
+func TestAddLocalCameraAndList(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfgPath := filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "camsnap", "config.yaml")
+
+	root := NewRootCommand("test")
+	root.SetArgs([]string{"--config", cfgPath, "add", "--name", "mbp", "--protocol", "local", "--device", "0"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("add local execute: %v", err)
+	}
+
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if len(cfg.Cameras) != 1 || cfg.Cameras[0].Protocol != "local" || cfg.Cameras[0].Device != "0" || cfg.Cameras[0].Host != "" {
+		t.Fatalf("local camera config = %#v", cfg.Cameras)
+	}
+
+	var output bytes.Buffer
+	root = NewRootCommand("test")
+	root.SetOut(&output)
+	root.SetArgs([]string{"--config", cfgPath, "list"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("list local execute: %v", err)
+	}
+	if !strings.Contains(output.String(), "device=0 proto=local") {
+		t.Fatalf("local list output = %q", output.String())
+	}
+}
+
+func TestAddLocalCameraValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "device required", args: []string{"add", "--name", "mbp", "--protocol", "local"}, want: "--device is required"},
+		{name: "host rejected", args: []string{"add", "--name", "mbp", "--protocol", "local", "--device", "0", "--host", "localhost"}, want: "--host is not valid"},
+		{name: "RTSP flag rejected", args: []string{"add", "--name", "mbp", "--protocol", "local", "--device", "0", "--rtsp-transport", "udp"}, want: "--rtsp-transport is not valid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			root := NewRootCommand("test")
+			root.SetArgs(tt.args)
+			err := root.Execute()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("Execute error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSnapAdHocLocalDevice(t *testing.T) {
+	ffmpegPath, argsPath := makeRecordingStubFFmpeg(t)
+	t.Setenv("PATH", ffmpegPath)
+	output := filepath.Join(t.TempDir(), "snap.jpg")
+
+	root := NewRootCommand("test")
+	root.SetArgs([]string{"snap", "--device", "0", "--framerate", "24", "--video-size", "1280x720", "--warmup", "1500ms", "--out", output})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("snap local: %v", err)
+	}
+	args := readRecordedArgs(t, argsPath)
+	inputFormat := "avfoundation"
+	if runtime.GOOS == "linux" {
+		inputFormat = "v4l2"
+	}
+	assertArgsContainSequence(t, args, "-f", inputFormat, "-framerate", "24", "-video_size", "1280x720", "-i", "0")
+	assertArgsContainSequence(t, args, "-t", "1.5", "-update", "1", "-q:v", "2", output)
+}
+
+func TestCaptureCameraAndDeviceAreMutuallyExclusive(t *testing.T) {
+	t.Setenv("PATH", makeStubFFmpeg(t))
+	root := NewRootCommand("test")
+	root.SetArgs([]string{"snap", "saved", "--device", "0", "--out", filepath.Join(t.TempDir(), "snap.jpg")})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("Execute error = %v", err)
+	}
+}
+
+func TestLocalCaptureRejectsExplicitRTSPFlags(t *testing.T) {
+	t.Setenv("PATH", makeStubFFmpeg(t))
+	root := NewRootCommand("test")
+	root.SetArgs([]string{"snap", "--device", "0", "--rtsp-transport", "udp", "--out", filepath.Join(t.TempDir(), "snap.jpg")})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "RTSP and audio flags") {
+		t.Fatalf("Execute error = %v", err)
 	}
 }
 

--- a/internal/cli/devices.go
+++ b/internal/cli/devices.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+type localDevice struct {
+	Index string `json:"index"`
+	Name  string `json:"name"`
+}
+
+var avfoundationDevicePattern = regexp.MustCompile(`\[(\d+)\]\s+(.+)$`)
+
+func newDevicesCmd() *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "devices",
+		Short: "List local video capture devices",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			devices, err := enumerateLocalDevices(runtime.GOOS)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent("", "  ")
+				return encoder.Encode(devices)
+			}
+			if len(devices) == 0 {
+				if runtime.GOOS == "darwin" {
+					cmd.Println("No local video devices found. Continuity Camera appears only while the iPhone is nearby and unlocked.")
+				} else {
+					cmd.Println("No local video devices found.")
+				}
+				return nil
+			}
+			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			_, _ = fmt.Fprintln(writer, "INDEX\tNAME")
+			for _, device := range devices {
+				_, _ = fmt.Fprintf(writer, "%s\t%s\n", device.Index, device.Name)
+			}
+			return writer.Flush()
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print devices as JSON")
+	return cmd
+}
+
+func enumerateLocalDevices(goos string) ([]localDevice, error) {
+	switch goos {
+	case "darwin":
+		output, err := exec.Command("ffmpeg", "-f", "avfoundation", "-list_devices", "true", "-i", "").CombinedOutput()
+		if err != nil {
+			var exitError *exec.ExitError
+			if !errors.As(err, &exitError) {
+				return nil, fmt.Errorf("list avfoundation devices: %w", err)
+			}
+		}
+		return parseAVFoundationDevices(string(output)), nil
+	case "linux":
+		paths, err := filepath.Glob("/dev/video*")
+		if err != nil {
+			return nil, fmt.Errorf("list v4l2 devices: %w", err)
+		}
+		devices := make([]localDevice, 0, len(paths))
+		for _, path := range paths {
+			devices = append(devices, localDevice{Index: strings.TrimPrefix(path, "/dev/video"), Name: path})
+		}
+		return devices, nil
+	default:
+		return nil, fmt.Errorf("local webcams are unsupported on %s", goos)
+	}
+}
+
+func parseAVFoundationDevices(stderr string) []localDevice {
+	devices := make([]localDevice, 0)
+	inVideoSection := false
+	for _, line := range strings.Split(stderr, "\n") {
+		lower := strings.ToLower(line)
+		switch {
+		case strings.Contains(lower, "avfoundation video devices:"):
+			inVideoSection = true
+			continue
+		case strings.Contains(lower, "avfoundation audio devices:"):
+			inVideoSection = false
+			continue
+		}
+		if !inVideoSection {
+			continue
+		}
+		matches := avfoundationDevicePattern.FindStringSubmatch(line)
+		if len(matches) == 3 {
+			devices = append(devices, localDevice{Index: matches[1], Name: strings.TrimSpace(matches[2])})
+		}
+	}
+	sort.Slice(devices, func(i, j int) bool { return devices[i].Index < devices[j].Index })
+	return devices
+}
+
+func localDeviceVisible(devices []localDevice, configured string) bool {
+	for _, device := range devices {
+		if device.Index == configured || device.Name == configured {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/devices_test.go
+++ b/internal/cli/devices_test.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseAVFoundationDevicesFixture(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/avfoundation_devices.txt")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	want := []localDevice{
+		{Index: "0", Name: "Capture screen 0"},
+	}
+	if got := parseAVFoundationDevices(string(fixture)); !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseAVFoundationDevices = %#v, want %#v", got, want)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,7 +20,7 @@ func newDoctorCmd() *cobra.Command {
 	var transport string
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Run basic checks (ffmpeg in PATH, config present, camera ports reachable)",
+		Short: "Check ffmpeg and configured RTSP/local cameras",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			sty := newStyler(cmd.OutOrStdout())
 
@@ -31,7 +33,8 @@ func newDoctorCmd() *cobra.Command {
 				return err
 			}
 
-			if mediaexec.HasBinary("ffmpeg") {
+			ffmpegFound := mediaexec.HasBinary("ffmpeg")
+			if ffmpegFound {
 				cmd.Println(sty.OK("✔ ffmpeg found in PATH"))
 			} else {
 				cmd.Println(sty.Err("✖ ffmpeg missing (install ffmpeg and retry)"))
@@ -43,7 +46,51 @@ func newDoctorCmd() *cobra.Command {
 				return nil
 			}
 
+			var (
+				localDevices    []localDevice
+				localDevicesErr error
+			)
 			for _, cam := range cfg.Cameras {
+				if strings.EqualFold(cam.Protocol, "local") {
+					if ffmpegFound {
+						localDevices, localDevicesErr = enumerateLocalDevices(runtime.GOOS)
+					} else {
+						localDevicesErr = fmt.Errorf("ffmpeg missing")
+					}
+					break
+				}
+			}
+
+			for _, cam := range cfg.Cameras {
+				if strings.EqualFold(cam.Protocol, "local") {
+					options, err := capture.Resolve(cam, (captureFlagValues{
+						transport: transport,
+						rtspAuth:  authMode,
+					}).overrides(cmd))
+					if err != nil {
+						cmd.Printf("%s %s local camera invalid: %v\n", sty.Err("✖"), cam.Name, err)
+						continue
+					}
+					if localDevicesErr != nil {
+						cmd.Printf("%s %s device enumeration failed: %v\n", sty.Err("✖"), cam.Name, localDevicesErr)
+						continue
+					}
+					if !localDeviceVisible(localDevices, cam.Device) {
+						cmd.Printf("%s %s device %q not found in local enumeration\n", sty.Err("✖"), cam.Name, cam.Device)
+						continue
+					}
+					if probe {
+						ctx, cancel := mediaexec.WithTimeout(context.Background(), timeout+2*time.Second)
+						err = runLocalCapture(ctx, localCaptureRequest{operation: localProbe, options: options})
+						cancel()
+						if err != nil {
+							cmd.Printf("%s %s local capture probe failed: %v\n", sty.Err("✖"), cam.Name, err)
+							continue
+						}
+					}
+					cmd.Printf("%s %s device %q visible\n", sty.OK("✔"), cam.Name, cam.Device)
+					continue
+				}
 				host := cam.Host
 				port := cam.Port
 				if port == 0 {
@@ -57,13 +104,19 @@ func newDoctorCmd() *cobra.Command {
 				}
 				options, err := capture.Resolve(cam, (captureFlagValues{
 					transport: transport,
+					rtspAuth:  authMode,
 				}).overrides(cmd))
 				if err != nil {
 					cmd.Printf("%s %s RTSP URL invalid: %v\n", sty.Err("✖"), cam.Name, err)
 					continue
 				}
 				if probe {
-					if err := probeRTSP(cmd, capture.ProbeArgs(options), timeout+2*time.Second, authMode); err != nil {
+					probeArgs, err := capture.ProbeArgs(options, runtime.GOOS)
+					if err != nil {
+						cmd.Printf("%s %s ffmpeg probe invalid: %v\n", sty.Err("✖"), cam.Name, err)
+						continue
+					}
+					if err := probeRTSP(cmd, probeArgs, timeout+2*time.Second, authMode); err != nil {
 						cmd.Printf("%s %s ffmpeg probe failed: %v\n", sty.Err("✖"), cam.Name, err)
 						continue
 					}
@@ -74,7 +127,7 @@ func newDoctorCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().DurationVar(&timeout, "timeout", 2*time.Second, "Dial timeout per camera")
-	cmd.Flags().BoolVar(&probe, "probe", false, "Use ffmpeg to probe each RTSP URL briefly")
+	cmd.Flags().BoolVar(&probe, "probe", false, "Use ffmpeg to probe each camera briefly")
 	cmd.Flags().StringVar(&authMode, "rtsp-auth", "auto", "RTSP auth mode: auto|basic|digest")
 	cmd.Flags().StringVar(&transport, "rtsp-transport", "tcp", "RTSP transport: tcp|udp (probe)")
 	return cmd

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/camsnap/internal/capture"
@@ -42,8 +43,13 @@ type captureFlagValues struct {
 	stream     string
 	client     string
 	path       string
+	rtspAuth   string
 	noAudio    bool
 	audioCodec string
+	device     string
+	framerate  int
+	videoSize  string
+	warmup     time.Duration
 }
 
 func (values captureFlagValues) overrides(cmd *cobra.Command) capture.Overrides {
@@ -52,9 +58,28 @@ func (values captureFlagValues) overrides(cmd *cobra.Command) capture.Overrides 
 		Stream:     changedString(cmd, "stream", values.stream),
 		Client:     changedString(cmd, "rtsp-client", values.client),
 		Path:       changedString(cmd, "path", values.path),
+		RTSPAuth:   changedString(cmd, "rtsp-auth", values.rtspAuth),
 		NoAudio:    changedBool(cmd, "no-audio", values.noAudio),
 		AudioCodec: changedString(cmd, "audio-codec", values.audioCodec),
+		Device:     changedString(cmd, "device", values.device),
+		Framerate:  changedInt(cmd, "framerate", values.framerate),
+		VideoSize:  changedString(cmd, "video-size", values.videoSize),
+		Warmup:     changedDuration(cmd, "warmup", values.warmup),
 	}
+}
+
+func changedInt(cmd *cobra.Command, name string, value int) *int {
+	if cmd.Flags().Changed(name) {
+		return &value
+	}
+	return nil
+}
+
+func changedDuration(cmd *cobra.Command, name string, value time.Duration) *time.Duration {
+	if cmd.Flags().Changed(name) {
+		return &value
+	}
+	return nil
 }
 
 func changedString(cmd *cobra.Command, name, value string) *string {
@@ -82,4 +107,29 @@ func loadConfigFromFlag(cmd *cobra.Command) (config.Config, string, error) {
 		return config.Config{}, "", err
 	}
 	return cfg, path, nil
+}
+
+func selectCaptureCamera(cmd *cobra.Command, args []string, cameraName, device string) (config.Camera, string, error) {
+	if cameraName == "" && len(args) > 0 {
+		cameraName = args[0]
+	}
+	if cameraName != "" && device != "" {
+		return config.Camera{}, "", fmt.Errorf("camera name and --device are mutually exclusive")
+	}
+	if cameraName == "" && device == "" {
+		return config.Camera{}, "", fmt.Errorf("--camera or --device is required")
+	}
+	if device != "" {
+		return config.Camera{Name: device, Protocol: "local", Device: device}, device, nil
+	}
+
+	cfg, _, err := loadConfigFromFlag(cmd)
+	if err != nil {
+		return config.Camera{}, "", err
+	}
+	cam, ok := findCamera(cfg, cameraName)
+	if !ok {
+		return config.Camera{}, "", fmt.Errorf("camera %q not found", cameraName)
+	}
+	return cam, cameraName, nil
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -29,6 +29,10 @@ func newListCmd() *cobra.Command {
 			sort.Slice(cfg.Cameras, func(i, j int) bool { return cfg.Cameras[i].Name < cfg.Cameras[j].Name })
 
 			for _, cam := range cfg.Cameras {
+				if strings.EqualFold(cam.Protocol, "local") {
+					cmd.Printf("%-12s device=%s proto=local\n", cam.Name, cam.Device)
+					continue
+				}
 				// avoid printing password
 				auth := cam.Username
 				if auth != "" && cam.Password != "" {

--- a/internal/cli/localrun.go
+++ b/internal/cli/localrun.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/steipete/camsnap/internal/capture"
+	mediaexec "github.com/steipete/camsnap/internal/exec"
+)
+
+type localCaptureOperation uint8
+
+const (
+	localSnap localCaptureOperation = iota
+	localClip
+	localWatch
+	localProbe
+)
+
+type localCaptureRequest struct {
+	operation localCaptureOperation
+	options   capture.Options
+	output    string
+	duration  time.Duration
+	threshold float64
+	onLine    func(string)
+}
+
+// runLocalCapture is the single execution seam for local camera captures. A
+// future native backend can replace this dispatcher without changing commands.
+func runLocalCapture(ctx context.Context, request localCaptureRequest) error {
+	var (
+		args []string
+		err  error
+	)
+	switch request.operation {
+	case localSnap:
+		args, err = capture.SnapArgs(request.options, request.output, runtime.GOOS)
+	case localClip:
+		args, err = capture.ClipArgs(request.options, request.duration, request.output, runtime.GOOS)
+	case localWatch:
+		args, err = capture.WatchArgs(request.options, request.threshold, runtime.GOOS)
+	case localProbe:
+		args, err = capture.ProbeArgs(request.options, runtime.GOOS)
+	default:
+		return fmt.Errorf("unknown local capture operation")
+	}
+	if err != nil {
+		return err
+	}
+
+	if request.operation == localWatch {
+		var evidence []string
+		logTail, exitErr, streamErr := mediaexec.RunFFmpegWithStderrLines(ctx, args, func(line string) {
+			if mediaexec.ClassifyError(line) != "unknown" || isSupportedModeLine(line) {
+				evidence = append(evidence, line)
+			}
+			if request.onLine != nil {
+				request.onLine(line)
+			}
+		})
+		if streamErr != nil {
+			return streamErr
+		}
+		if exitErr != nil && ctx.Err() == nil {
+			evidence = append(evidence, logTail)
+			return localCaptureFailure(exitErr, strings.Join(evidence, "\n"))
+		}
+		return nil
+	}
+
+	output, err := mediaexec.RunFFmpegWithOutput(ctx, args...)
+	if err != nil {
+		return localCaptureFailure(err, output)
+	}
+	return nil
+}
+
+func localCaptureFailure(err error, output string) error {
+	class := mediaexec.ClassifyError(output)
+	details := ""
+	if modes := supportedModeText(output); modes != "" && !strings.Contains(err.Error(), modes) {
+		details += "\n" + modes
+	}
+	if class == "permission" {
+		details += "\nGrant Camera access to the launching terminal in System Settings → Privacy & Security → Camera. Over SSH there is no permission prompt; run `tccutil reset Camera` locally to re-prompt."
+	}
+	return fmt.Errorf("local capture failed (%s): %w%s", class, err, details)
+}
+
+func supportedModeText(output string) string {
+	lines := strings.Split(output, "\n")
+	var relevant []string
+	inModes := false
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "selected framerate") && strings.Contains(lower, "not supported") {
+			relevant = append(relevant, line)
+		}
+		if strings.Contains(lower, "supported modes:") {
+			inModes = true
+			relevant = append(relevant, line)
+			continue
+		}
+		if inModes {
+			if strings.TrimSpace(line) == "" {
+				break
+			}
+			relevant = append(relevant, line)
+		}
+	}
+	return strings.Join(relevant, "\n")
+}
+
+func isSupportedModeLine(line string) bool {
+	lower := strings.ToLower(line)
+	return strings.Contains(lower, "supported modes:") ||
+		(strings.Contains(lower, "selected framerate") && strings.Contains(lower, "not supported"))
+}

--- a/internal/cli/localrun_test.go
+++ b/internal/cli/localrun_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestLocalCapturePermissionRemediation(t *testing.T) {
+	err := localCaptureFailure(errors.New("exit status 1"), "Failed to create AVCaptureDeviceInput: Operation not permitted")
+	for _, want := range []string{"(permission)", "System Settings → Privacy & Security → Camera", "Over SSH", "tccutil reset Camera"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestLocalCaptureIncludesSupportedModes(t *testing.T) {
+	output := "Selected framerate (60.000000) is not supported by the device.\nSupported modes:\n  1280x720@[1.000000 30.000000]fps\n"
+	err := localCaptureFailure(errors.New("exit status 1"), output)
+	if !strings.Contains(err.Error(), "1280x720@[1.000000 30.000000]fps") {
+		t.Fatalf("supported mode missing from error: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,7 +12,7 @@ import (
 func NewRootCommand(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "camsnap",
-		Short:         "camsnap captures frames and clips from RTSP cameras (Tapo first, Ubiquiti next)",
+		Short:         "camsnap captures frames and clips from RTSP cameras and local webcams",
 		Long:          colorizeLong(),
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -30,6 +30,7 @@ func NewRootCommand(version string) *cobra.Command {
 		newSnapCmd(),
 		newClipCmd(),
 		newDiscoverCmd(),
+		newDevicesCmd(),
 		newWatchCmd(),
 		newDoctorCmd(),
 		newVersionCmd(version),
@@ -50,6 +51,8 @@ func exampleText() string {
 	var b strings.Builder
 	b.WriteString("  camsnap add --name kitchen --host 192.168.0.175 --user tapo --pass secret --rtsp-transport udp --stream stream2\n")
 	b.WriteString("  camsnap snap kitchen --out shot.jpg\n")
+	b.WriteString("  camsnap snap --device 0 --out webcam.jpg\n")
+	b.WriteString("  camsnap devices\n")
 	b.WriteString("  camsnap clip kitchen --dur 5s --no-audio --out clip.mp4\n")
 	b.WriteString("  camsnap watch kitchen --threshold 0.2 --cooldown 5s --json --action 'touch /tmp/motion'\n")
 	b.WriteString("  camsnap doctor --probe --rtsp-transport udp\n")
@@ -63,7 +66,7 @@ func colorizeLong() string {
 	r := termenv.String().Foreground(p.Color("#e53935")).Styled
 
 	return fmt.Sprintf("%s %s\n\n%s\n  %s\n  %s\n  %s\n",
-		b("camsnap"), "– capture frames/clips and motion from RTSP/ONVIF cameras.",
+		b("camsnap"), "– capture frames/clips and motion from RTSP/ONVIF cameras and local webcams.",
 		b("Common commands:"),
 		g("snap")+"     grab a frame (positional camera name allowed)",
 		g("clip")+"     short clip; drop audio with --no-audio",

--- a/internal/cli/snap.go
+++ b/internal/cli/snap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -21,17 +22,41 @@ func newSnapCmd() *cobra.Command {
 	var stream string
 	var client string
 	var path string
+	var device string
+	var framerate int
+	var videoSize string
+	var warmup time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "snap",
 		Short: "Capture a single frame to a file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// allow positional camera name if --camera not set
-			if cameraName == "" && len(args) > 0 {
-				cameraName = args[0]
+			if !mediaexec.HasBinary("ffmpeg") {
+				return fmt.Errorf("ffmpeg not found in PATH")
 			}
-			if cameraName == "" {
-				return fmt.Errorf("--camera is required")
+			cam, selectedName, err := selectCaptureCamera(cmd, args, cameraName, device)
+			if err != nil {
+				return err
+			}
+			cameraName = selectedName
+			options, err := capture.Resolve(cam, (captureFlagValues{
+				transport: transport,
+				stream:    stream,
+				client:    client,
+				path:      path,
+				rtspAuth:  authMode,
+				device:    device,
+				framerate: framerate,
+				videoSize: videoSize,
+				warmup:    warmup,
+			}).overrides(cmd))
+			if err != nil {
+				return err
+			}
+			if options.Kind == capture.KindRTSP {
+				if _, ok := parseRTSPAuth(authMode); !ok {
+					return fmt.Errorf("invalid --rtsp-auth (use auto|basic|digest)")
+				}
 			}
 			if outPath == "" {
 				tmp, err := os.CreateTemp("", "camsnap-*.jpg")
@@ -44,44 +69,21 @@ func newSnapCmd() *cobra.Command {
 				outPath = tmp.Name()
 				cmd.Printf("No --out provided, writing snapshot to %s\n", outPath)
 			}
-			if !mediaexec.HasBinary("ffmpeg") {
-				return fmt.Errorf("ffmpeg not found in PATH")
-			}
-
-			cfgFlag, err := configPathFlag(cmd)
-			if err != nil {
-				return err
-			}
-			cfg, _, err := loadConfig(cfgFlag)
-			if err != nil {
-				return err
-			}
-			cam, ok := findCamera(cfg, cameraName)
-			if !ok {
-				return fmt.Errorf("camera %q not found", cameraName)
-			}
-
-			if _, ok := parseRTSPAuth(authMode); !ok {
-				return fmt.Errorf("invalid --rtsp-auth (use auto|basic|digest)")
-			}
-			options, err := capture.Resolve(cam, (captureFlagValues{
-				transport: transport,
-				stream:    stream,
-				client:    client,
-				path:      path,
-			}).overrides(cmd))
-			if err != nil {
-				return err
-			}
 
 			ctx, cancel := mediaexec.WithTimeout(context.Background(), timeout)
 			defer cancel()
+			if options.Kind == capture.KindLocal {
+				return runLocalCapture(ctx, localCaptureRequest{operation: localSnap, options: options, output: outPath})
+			}
 
 			if options.Client == "gortsplib" {
 				return rtspclient.GrabFrameViaGort(ctx, options.URL, options.Transport, outPath, timeout)
 			}
 
-			ffArgs := capture.SnapArgs(options, outPath)
+			ffArgs, err := capture.SnapArgs(options, outPath, runtime.GOOS)
+			if err != nil {
+				return err
+			}
 			return mediaexec.RunFFmpeg(ctx, ffArgs...)
 		},
 	}
@@ -94,6 +96,10 @@ func newSnapCmd() *cobra.Command {
 	cmd.Flags().StringVar(&stream, "stream", "", "RTSP path segment (stream1 or stream2); ignored if --path is set")
 	cmd.Flags().StringVar(&path, "path", "", "Custom RTSP path (overrides --stream), e.g., /Bfy... from UniFi Protect")
 	cmd.Flags().StringVar(&client, "rtsp-client", "ffmpeg", "RTSP client: ffmpeg|gortsplib")
+	cmd.Flags().StringVar(&device, "device", "", "Local video device index, name, or /dev/videoN path")
+	cmd.Flags().IntVar(&framerate, "framerate", 30, "Local capture framerate")
+	cmd.Flags().StringVar(&videoSize, "video-size", "", "Local capture size (e.g., 1280x720)")
+	cmd.Flags().DurationVar(&warmup, "warmup", time.Second, "Local camera auto-exposure warmup")
 
 	return cmd
 }

--- a/internal/cli/testdata/avfoundation_devices.txt
+++ b/internal/cli/testdata/avfoundation_devices.txt
@@ -1,0 +1,7 @@
+ffmpeg version 8.1.2 Copyright (c) 2000-2026 the FFmpeg developers
+[AVFoundation indev @ 0x71ac18140] AVFoundation video devices:
+[AVFoundation indev @ 0x71ac18140] [0] Capture screen 0
+[AVFoundation indev @ 0x71ac18140] AVFoundation audio devices:
+[AVFoundation indev @ 0x71ac18140] [0] BlackHole 2ch
+[AVFoundation indev @ 0x71ac18140] [1] Jump Desktop Microphone
+[in#0 @ 0x71ac18000] Error opening input: Input/output error

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	osexec "os/exec"
+	gort "runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -25,17 +26,14 @@ func newWatchCmd() *cobra.Command {
 	var transport string
 	var stream string
 	var path string
+	var device string
+	var framerate int
+	var videoSize string
 
 	cmd := &cobra.Command{
 		Use:   "watch",
 		Short: "Run motion detection and execute an action",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if cameraName == "" && len(args) > 0 {
-				cameraName = args[0]
-			}
-			if cameraName == "" {
-				return fmt.Errorf("--camera is required")
-			}
 			if action == "" {
 				return fmt.Errorf("--action is required (e.g., \"say motion\" or \"touch /tmp/motion\")")
 			}
@@ -45,28 +43,27 @@ func newWatchCmd() *cobra.Command {
 			if !mediaexec.HasBinary("ffmpeg") {
 				return fmt.Errorf("ffmpeg not found in PATH")
 			}
-			cfgFlag, err := configPathFlag(cmd)
+			cam, selectedName, err := selectCaptureCamera(cmd, args, cameraName, device)
 			if err != nil {
 				return err
 			}
-			cfg, _, err := loadConfig(cfgFlag)
-			if err != nil {
-				return err
-			}
-			cam, ok := findCamera(cfg, cameraName)
-			if !ok {
-				return fmt.Errorf("camera %q not found", cameraName)
-			}
-			if _, ok := parseRTSPAuth(authMode); !ok {
-				return fmt.Errorf("invalid --rtsp-auth (use auto|basic|digest)")
-			}
+			cameraName = selectedName
 			options, err := capture.Resolve(cam, (captureFlagValues{
 				transport: transport,
 				stream:    stream,
 				path:      path,
+				rtspAuth:  authMode,
+				device:    device,
+				framerate: framerate,
+				videoSize: videoSize,
 			}).overrides(cmd))
 			if err != nil {
 				return err
+			}
+			if options.Kind == capture.KindRTSP {
+				if _, ok := parseRTSPAuth(authMode); !ok {
+					return fmt.Errorf("invalid --rtsp-auth (use auto|basic|digest)")
+				}
 			}
 			if tmpl != "" {
 				action, err = applyTemplate(tmpl, cam.Name, 0, time.Now())
@@ -82,8 +79,15 @@ func newWatchCmd() *cobra.Command {
 				defer cancel()
 			}
 
-			ffArgs := capture.WatchArgs(options, threshold)
-			return watchMotion(ctx, cameraName, ffArgs, cooldown, action, tmpl, jsonOutput, cmd)
+			onLine := motionLineHandler(ctx, cameraName, cooldown, action, tmpl, jsonOutput, cmd)
+			if options.Kind == capture.KindLocal {
+				return runLocalCapture(ctx, localCaptureRequest{operation: localWatch, options: options, threshold: threshold, onLine: onLine})
+			}
+			ffArgs, err := capture.WatchArgs(options, threshold, gort.GOOS)
+			if err != nil {
+				return err
+			}
+			return watchMotion(ctx, ffArgs, onLine)
 		},
 	}
 
@@ -98,13 +102,28 @@ func newWatchCmd() *cobra.Command {
 	cmd.Flags().StringVar(&transport, "rtsp-transport", "tcp", "RTSP transport: tcp|udp")
 	cmd.Flags().StringVar(&stream, "stream", "", "RTSP path segment (stream1 or stream2); ignored if --path is set")
 	cmd.Flags().StringVar(&path, "path", "", "Custom RTSP path (overrides --stream), e.g., /Bfy... from UniFi Protect")
+	cmd.Flags().StringVar(&device, "device", "", "Local video device index, name, or /dev/videoN path")
+	cmd.Flags().IntVar(&framerate, "framerate", 30, "Local capture framerate")
+	cmd.Flags().StringVar(&videoSize, "video-size", "", "Local capture size (e.g., 1280x720)")
 
 	return cmd
 }
 
-func watchMotion(ctx context.Context, cameraName string, ffArgs []string, cooldown time.Duration, action string, tmpl string, jsonOutput bool, cmd *cobra.Command) error {
+func watchMotion(ctx context.Context, ffArgs []string, onLine func(string)) error {
+	logTail, exitErr, err := mediaexec.RunFFmpegWithStderrLines(ctx, ffArgs, onLine)
+	if err != nil {
+		return err
+	}
+	if exitErr != nil && ctx.Err() == nil {
+		class := mediaexec.ClassifyError(logTail)
+		return fmt.Errorf("ffmpeg exited: %w (%s)", exitErr, class)
+	}
+	return nil
+}
+
+func motionLineHandler(ctx context.Context, cameraName string, cooldown time.Duration, action string, tmpl string, jsonOutput bool, cmd *cobra.Command) func(string) {
 	lastTrigger := time.Time{}
-	logTail, exitErr, err := mediaexec.RunFFmpegWithStderrLines(ctx, ffArgs, func(line string) {
+	return func(line string) {
 		if score, ok := parseSceneScore(line); ok {
 			now := time.Now()
 			if lastTrigger.IsZero() || now.Sub(lastTrigger) >= cooldown {
@@ -123,15 +142,7 @@ func watchMotion(ctx context.Context, cameraName string, ffArgs []string, cooldo
 				runAction(ctx, act, score, now, cameraName)
 			}
 		}
-	})
-	if err != nil {
-		return err
 	}
-	if exitErr != nil && ctx.Err() == nil {
-		class := mediaexec.ClassifyError(logTail)
-		return fmt.Errorf("ffmpeg exited: %w (%s)", exitErr, class)
-	}
-	return nil
 }
 
 func parseSceneScore(line string) (float64, bool) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Camera struct {
 	Protocol      string `yaml:"protocol"`
 	Username      string `yaml:"username"`
 	Password      string `yaml:"password"`
+	Device        string `yaml:"device,omitempty"`
 	Path          string `yaml:"path,omitempty"`           // explicit RTSP path (e.g., /Bfy... from UniFi Protect)
 	RTSPTransport string `yaml:"rtsp_transport,omitempty"` // tcp|udp
 	Stream        string `yaml:"stream,omitempty"`         // stream1|stream2

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,11 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 				NoAudio:       true,
 				AudioCodec:    "aac",
 			},
+			{
+				Name:     "laptop",
+				Protocol: "local",
+				Device:   "0",
+			},
 		},
 	}
 
@@ -37,11 +42,14 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if len(loaded.Cameras) != 1 || loaded.Cameras[0].Name != "front" {
+	if len(loaded.Cameras) != 2 || loaded.Cameras[0].Name != "front" {
 		t.Fatalf("round trip mismatch: %#v", loaded)
 	}
 	if loaded.Cameras[0].RTSPTransport != "udp" || loaded.Cameras[0].Stream != "stream2" || loaded.Cameras[0].RTSPClient != "gortsplib" || !loaded.Cameras[0].NoAudio || loaded.Cameras[0].AudioCodec != "aac" {
 		t.Fatalf("round trip custom fields mismatch: %#v", loaded.Cameras[0])
+	}
+	if loaded.Cameras[1].Protocol != "local" || loaded.Cameras[1].Device != "0" {
+		t.Fatalf("round trip local device mismatch: %#v", loaded.Cameras[1])
 	}
 }
 

--- a/internal/exec/ffmpeg.go
+++ b/internal/exec/ffmpeg.go
@@ -101,17 +101,21 @@ func HasBinary(name string) bool {
 	return err == nil
 }
 
-// ClassifyError inspects ffmpeg stderr to differentiate auth vs network errors.
+// ClassifyError inspects ffmpeg stderr to differentiate common failures.
 func ClassifyError(stderr string) string {
 	lower := strings.ToLower(stderr)
 	switch {
+	case strings.Contains(lower, "operation not permitted") ||
+		strings.Contains(lower, "failed to create avcapturedeviceinput") ||
+		strings.Contains(lower, "not authorized to capture video"):
+		return "permission"
 	case strings.Contains(lower, "401") || strings.Contains(lower, "unauthorized") || strings.Contains(lower, "auth"):
 		return "auth"
 	case strings.Contains(lower, "connection refused"):
 		return "network-refused"
 	case strings.Contains(lower, "timed out") || strings.Contains(lower, "timeout"):
 		return "network-timeout"
-	case strings.Contains(lower, "not found"):
+	case strings.Contains(lower, "not found") || strings.Contains(lower, "no such file or directory") || strings.Contains(lower, "could not find video device"):
 		return "not-found"
 	default:
 		return "unknown"

--- a/internal/exec/ffmpeg_test.go
+++ b/internal/exec/ffmpeg_test.go
@@ -13,9 +13,13 @@ func TestClassifyError(t *testing.T) {
 	}{
 		{"401 Unauthorized", "auth"},
 		{"Server returned 401 unauthorized", "auth"},
+		{"Operation not permitted", "permission"},
+		{"Failed to create AVCaptureDeviceInput", "permission"},
+		{"Not Authorized To Capture Video", "permission"},
 		{"Connection refused", "network-refused"},
 		{"timed out", "network-timeout"},
 		{"not found", "not-found"},
+		{"/dev/video9: No such file or directory", "not-found"},
 		{"weird message", "unknown"},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## Summary

- add configured and ad-hoc local webcam capture through AVFoundation on macOS and v4l2 on Linux
- add local-aware snapshot warmup, H.264 video-only clips, motion watch input, and a single backend dispatch seam
- add `camsnap devices` table/JSON enumeration, local doctor checks, TCC permission guidance, and supported-framerate diagnostics
- preserve RTSP argument behavior while extending the shared resolver to reject source-incompatible flags
- document local webcam setup, platform limitations, and the per-camera-default fix from PR #9

## Proof

- `make fmt`
- `make lint`
- `make test`
- `GOOS=linux go build ./...`
- live `go run ./cmd/camsnap devices`:

```text
INDEX  NAME
0      Capture screen 0
```

- autoreview: clean, no accepted/actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
