### PR TITLE
fix(release): keep version injection in darwin ldflags overrides

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ builds:
           - CGO_CFLAGS=-arch arm64
           - CGO_LDFLAGS=-arch arm64
         ldflags:
-          - '-linkmode external -extldflags "-Wl,-sectcreate,__TEXT,__info_plist,{{ .Env.PWD }}/internal/avf/Info.plist"'
+          - '-s -w -X main.version={{ .Version }} -linkmode external -extldflags "-Wl,-sectcreate,__TEXT,__info_plist,{{ .Env.PWD }}/internal/avf/Info.plist"'
       - goos: darwin
         goarch: amd64
         env:
@@ -36,7 +36,7 @@ builds:
           - CGO_CFLAGS=-arch x86_64
           - CGO_LDFLAGS=-arch x86_64
         ldflags:
-          - '-linkmode external -extldflags "-Wl,-sectcreate,__TEXT,__info_plist,{{ .Env.PWD }}/internal/avf/Info.plist"'
+          - '-s -w -X main.version={{ .Version }} -linkmode external -extldflags "-Wl,-sectcreate,__TEXT,__info_plist,{{ .Env.PWD }}/internal/avf/Info.plist"'
     hooks:
       post:
         - cmd: './scripts/sign-darwin.sh "{{ .Path }}"'

--- a/cmd/camsnap/main.go
+++ b/cmd/camsnap/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/steipete/camsnap/internal/cli"
 )
 
-var version = "0.2.2"
+var version = "dev"
 
 func main() {
 	root := cli.NewRootCommand(version)


### PR DESCRIPTION
Found during 0.3.0 end-to-end verification: the darwin `overrides.ldflags` in `.goreleaser.yaml` replace goreleaser's default ldflags, which silently dropped `-X main.version` — darwin release binaries would have reported the stale hardcoded `0.2.2`.

- Re-adds `-s -w -X main.version={{ .Version }}` to both darwin overrides.
- Defaults the in-source version to `dev` so non-release builds are honest.

Proof: `goreleaser build --snapshot --single-target` binary now reports `0.2.2-SNAPSHOT-d05287f` (version derives from the latest tag; a `v0.3.0` tag yields 0.3.0) and still carries the `__TEXT,__info_plist` section. Tests + lint green; autoreview clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
