### PR TITLE
feat: add ptz command for UVC pan/tilt/zoom control on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## 0.3.1 - Unreleased
+## 0.4.0 - Unreleased
+- Add pan, tilt, zoom, status, and home controls for UVC USB cameras on macOS.
 - Rewrite the README around installation, first capture, and focused camera setup guides.
 
 ## 0.3.0 - 2026-08-02

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ camsnap stores configuration in `~/.config/camsnap/config.yaml`, or `$XDG_CONFIG
 | `watch` | Detect scene changes and run a shell action. |
 | `discover` | Find ONVIF devices on the local network. |
 | `devices` | List local video inputs. |
+| `ptz` | Control pan, tilt, and zoom on supported USB webcams. |
 | `doctor` | Check `ffmpeg`, connectivity, and optional capture probes. |
 
 Run `camsnap <command> --help` for the complete flags and defaults.
@@ -114,9 +115,13 @@ On macOS, official builds use native AVFoundation for device listing and snapsho
 ```sh
 camsnap devices
 camsnap snap --device 0 --out webcam.jpg
+camsnap ptz status --device 0
+camsnap ptz goto --device 0 --pan 12.5 --tilt -5 --zoom 50
+camsnap ptz move --device 0 --pan -10 --zoom 5
+camsnap ptz home --device 0
 ```
 
-See [Local webcams](docs/local-webcams.md) for stable macOS device selectors, Camera permission behavior, Linux device paths, and backend selection.
+See [Local webcams](docs/local-webcams.md) for stable macOS device selectors, Camera permission behavior, UVC PTZ control, Linux device paths, and backend selection.
 
 ## Platform support
 

--- a/docs/local-webcams.md
+++ b/docs/local-webcams.md
@@ -52,6 +52,23 @@ tccutil reset Camera
 
 Continuity Camera appears only while the iPhone is nearby and unlocked.
 
+## Pan, tilt, and zoom
+
+On macOS, `camsnap ptz` controls USB webcams that advertise standard UVC camera-terminal pan, tilt, or zoom controls. It accepts the same native index, stable AVFoundation ID, or camera name as `snap --device`; omitting `--device` selects the default camera.
+
+```sh
+camsnap ptz status --device 0
+camsnap ptz goto --device 0 --pan 12.5 --tilt -5 --zoom 50
+camsnap ptz move --device 0 --pan -10 --zoom 5
+camsnap ptz home --device 0
+```
+
+`goto` uses absolute pan and tilt angles in degrees and zoom from 0–100 percent. `move` takes degree deltas and zoom percentage-point deltas. Values are clamped and snapped to the ranges reported by the camera, and the command prints the positions actually applied. `home` uses each control's UVC default, falling back to zero pan/tilt and minimum zoom when a device does not report defaults. Every subcommand supports `--json`.
+
+The status table shows raw UVC ranges: pan and tilt use arcseconds, while zoom units are device-specific. Relative moves are implemented as a current-position read followed by a clamped absolute write because native UVC relative-speed controls vary between devices.
+
+PTZ requires a cgo-enabled macOS build and a directly attached USB UVC camera with absolute controls. Built-in cameras, Studio Display cameras, Continuity Camera, and devices that do not expose UVC PTZ controls return a named unsupported-camera error.
+
 ## Building the native backend
 
 `make build` embeds the Camera usage-description plist and applies an ad-hoc signature. Set `CAMSNAP_CODESIGN_IDENTITY` to use a local Developer ID identity instead.

--- a/internal/cli/ptz.go
+++ b/internal/cli/ptz.go
@@ -1,0 +1,372 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/camsnap/internal/uvc"
+)
+
+type ptzController interface {
+	Capabilities() uvc.Capabilities
+	Status() (uvc.Status, error)
+	SetPanTilt(pan, tilt int32) (int32, int32, error)
+	SetZoom(zoom int32) (int32, error)
+	Home() (uvc.Status, error)
+	Close() error
+}
+
+type ptzOptions struct {
+	device     string
+	jsonOutput bool
+}
+
+type ptzAngleOutput struct {
+	Degrees float64   `json:"degrees"`
+	Raw     int32     `json:"raw"`
+	Range   uvc.Range `json:"range"`
+}
+
+type ptzZoomOutput struct {
+	Percent float64   `json:"percent"`
+	Raw     int32     `json:"raw"`
+	Range   uvc.Range `json:"range"`
+}
+
+type ptzStatusOutput struct {
+	Device       localDevice      `json:"device"`
+	Capabilities uvc.Capabilities `json:"capabilities"`
+	Pan          *ptzAngleOutput  `json:"pan,omitempty"`
+	Tilt         *ptzAngleOutput  `json:"tilt,omitempty"`
+	Zoom         *ptzZoomOutput   `json:"zoom,omitempty"`
+}
+
+var (
+	ptzResolveDevice  = resolveNativePTZDevice
+	ptzOpenController = openNativePTZController
+)
+
+func newPTZCmd() *cobra.Command {
+	options := &ptzOptions{}
+	cmd := &cobra.Command{
+		Use:   "ptz",
+		Short: "Control pan, tilt, and zoom on a local USB camera",
+	}
+	cmd.PersistentFlags().StringVar(&options.device, "device", "", "Local video device index, ID, or name (default: default camera)")
+	cmd.PersistentFlags().BoolVar(&options.jsonOutput, "json", false, "Print PTZ status as JSON")
+	cmd.AddCommand(
+		newPTZStatusCmd(options),
+		newPTZGotoCmd(options),
+		newPTZMoveCmd(options),
+		newPTZHomeCmd(options),
+	)
+	return cmd
+}
+
+func newPTZStatusCmd(options *ptzOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show PTZ capabilities, positions, and ranges",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			device, controller, err := openPTZ(options.device)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = controller.Close() }()
+
+			status, err := controller.Status()
+			if err != nil {
+				return fmt.Errorf("read PTZ status for camera %q: %w", device.Name, err)
+			}
+			return writePTZStatus(cmd.OutOrStdout(), options.jsonOutput, makePTZStatusOutput(device, controller.Capabilities(), status))
+		},
+	}
+}
+
+func newPTZGotoCmd(options *ptzOptions) *cobra.Command {
+	var pan, tilt, zoom float64
+	cmd := &cobra.Command{
+		Use:   "goto",
+		Short: "Move to absolute pan, tilt, or zoom positions",
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return validatePTZMotionFlags(cmd, pan, tilt, zoom)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPTZMotion(cmd, options, false, pan, tilt, zoom)
+		},
+	}
+	cmd.Flags().Float64Var(&pan, "pan", 0, "Absolute pan angle in degrees")
+	cmd.Flags().Float64Var(&tilt, "tilt", 0, "Absolute tilt angle in degrees")
+	cmd.Flags().Float64Var(&zoom, "zoom", 0, "Absolute zoom position as a percentage")
+	return cmd
+}
+
+func newPTZMoveCmd(options *ptzOptions) *cobra.Command {
+	var pan, tilt, zoom float64
+	cmd := &cobra.Command{
+		Use:   "move",
+		Short: "Move by relative pan, tilt, or zoom deltas",
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return validatePTZMotionFlags(cmd, pan, tilt, zoom)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPTZMotion(cmd, options, true, pan, tilt, zoom)
+		},
+	}
+	cmd.Flags().Float64Var(&pan, "pan", 0, "Relative pan delta in degrees")
+	cmd.Flags().Float64Var(&tilt, "tilt", 0, "Relative tilt delta in degrees")
+	cmd.Flags().Float64Var(&zoom, "zoom", 0, "Relative zoom delta in percentage points")
+	return cmd
+}
+
+func newPTZHomeCmd(options *ptzOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "home",
+		Short: "Reset pan, tilt, and zoom to their defaults",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			device, controller, err := openPTZ(options.device)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = controller.Close() }()
+
+			status, err := controller.Home()
+			if err != nil {
+				return fmt.Errorf("home camera %q: %w", device.Name, err)
+			}
+			return writePTZStatus(cmd.OutOrStdout(), options.jsonOutput, makePTZStatusOutput(device, controller.Capabilities(), status))
+		},
+	}
+}
+
+func validatePTZMotionFlags(cmd *cobra.Command, pan, tilt, zoom float64) error {
+	changed := false
+	for _, flag := range []string{"pan", "tilt", "zoom"} {
+		if cmd.Flags().Changed(flag) {
+			changed = true
+		}
+	}
+	if !changed {
+		return fmt.Errorf("at least one of --pan, --tilt, or --zoom is required")
+	}
+	for flag, value := range map[string]float64{"pan": pan, "tilt": tilt, "zoom": zoom} {
+		if cmd.Flags().Changed(flag) && (math.IsNaN(value) || math.IsInf(value, 0)) {
+			return fmt.Errorf("--%s must be a finite number", flag)
+		}
+	}
+	return nil
+}
+
+func runPTZMotion(cmd *cobra.Command, options *ptzOptions, relative bool, pan, tilt, zoom float64) error {
+	device, controller, err := openPTZ(options.device)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = controller.Close() }()
+
+	capabilities := controller.Capabilities()
+	status, err := controller.Status()
+	if err != nil {
+		return fmt.Errorf("read PTZ status for camera %q: %w", device.Name, err)
+	}
+
+	panChanged := cmd.Flags().Changed("pan")
+	tiltChanged := cmd.Flags().Changed("tilt")
+	panTiltChanged := panChanged || tiltChanged
+	zoomChanged := cmd.Flags().Changed("zoom")
+	if panTiltChanged && (!capabilities.PanTiltAbsolute || status.Pan == nil || status.Tilt == nil) {
+		return fmt.Errorf("camera %q does not support absolute UVC pan/tilt control", device.Name)
+	}
+	if zoomChanged && (!capabilities.ZoomAbsolute || status.Zoom == nil) {
+		return fmt.Errorf("camera %q does not support absolute UVC zoom control", device.Name)
+	}
+
+	if panTiltChanged {
+		panValue := status.Pan.Cur
+		tiltValue := status.Tilt.Cur
+		if panChanged {
+			panValue = uvc.DegreesToArcsec(pan)
+			if relative {
+				panValue = addInt32(status.Pan.Cur, panValue)
+			}
+		}
+		if tiltChanged {
+			tiltValue = uvc.DegreesToArcsec(tilt)
+			if relative {
+				tiltValue = addInt32(status.Tilt.Cur, tiltValue)
+			}
+		}
+		if _, _, err := controller.SetPanTilt(panValue, tiltValue); err != nil {
+			return fmt.Errorf("set pan/tilt for camera %q: %w", device.Name, err)
+		}
+	}
+
+	if zoomChanged {
+		zoomPercent := zoom
+		if relative {
+			zoomPercent += status.Zoom.Range.PercentOf(status.Zoom.Cur)
+		}
+		if _, err := controller.SetZoom(status.Zoom.Range.FromPercent(zoomPercent)); err != nil {
+			return fmt.Errorf("set zoom for camera %q: %w", device.Name, err)
+		}
+	}
+
+	status, err = controller.Status()
+	if err != nil {
+		return fmt.Errorf("read applied PTZ status for camera %q: %w", device.Name, err)
+	}
+	return writePTZStatus(cmd.OutOrStdout(), options.jsonOutput, makePTZStatusOutput(device, capabilities, status))
+}
+
+func openPTZ(selector string) (localDevice, ptzController, error) {
+	device, err := ptzResolveDevice(selector)
+	if err != nil {
+		name := selector
+		if name == "" {
+			name = "default camera"
+		}
+		return localDevice{}, nil, fmt.Errorf("resolve PTZ camera %q: %w", name, err)
+	}
+	controller, err := ptzOpenController(device.ID)
+	if err != nil {
+		return localDevice{}, nil, fmt.Errorf("camera %q does not support USB UVC PTZ control: %w", device.Name, err)
+	}
+	if !controller.Capabilities().Any() {
+		_ = controller.Close()
+		return localDevice{}, nil, fmt.Errorf("camera %q does not advertise any UVC PTZ controls", device.Name)
+	}
+	return device, controller, nil
+}
+
+func resolveNativePTZDevice(selector string) (localDevice, error) {
+	devices, err := nativeEnumerateLocalDevices()
+	if err != nil {
+		return localDevice{}, fmt.Errorf("enumerate native cameras: %w", err)
+	}
+	if selector != "" {
+		return resolveNativeDevice(devices, selector)
+	}
+	if device, ok := defaultNativeDevice(devices); ok {
+		return device, nil
+	}
+	return localDevice{}, fmt.Errorf("no default native camera is available")
+}
+
+func makePTZStatusOutput(device localDevice, capabilities uvc.Capabilities, status uvc.Status) ptzStatusOutput {
+	output := ptzStatusOutput{Device: device, Capabilities: capabilities}
+	if status.Pan != nil {
+		output.Pan = &ptzAngleOutput{
+			Degrees: uvc.ArcsecToDegrees(status.Pan.Cur),
+			Raw:     status.Pan.Cur,
+			Range:   status.Pan.Range,
+		}
+	}
+	if status.Tilt != nil {
+		output.Tilt = &ptzAngleOutput{
+			Degrees: uvc.ArcsecToDegrees(status.Tilt.Cur),
+			Raw:     status.Tilt.Cur,
+			Range:   status.Tilt.Range,
+		}
+	}
+	if status.Zoom != nil {
+		output.Zoom = &ptzZoomOutput{
+			Percent: status.Zoom.Range.PercentOf(status.Zoom.Cur),
+			Raw:     status.Zoom.Cur,
+			Range:   status.Zoom.Range,
+		}
+	}
+	return output
+}
+
+func writePTZStatus(output io.Writer, jsonOutput bool, status ptzStatusOutput) error {
+	if jsonOutput {
+		encoder := json.NewEncoder(output)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(status)
+	}
+
+	if _, err := fmt.Fprintf(output, "Device: %s (%s)\n", status.Device.Name, status.Device.ID); err != nil {
+		return fmt.Errorf("write PTZ device: %w", err)
+	}
+	writer := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "CONTROL\tABSOLUTE\tRELATIVE\tVALUE\tRAW\tMIN\tMAX\tRES\tDEFAULT")
+	writePTZRow(writer, "PAN", status.Capabilities.PanTiltAbsolute, status.Capabilities.PanTiltRelative, angleValue(status.Pan), angleRaw(status.Pan), angleRange(status.Pan))
+	writePTZRow(writer, "TILT", status.Capabilities.PanTiltAbsolute, status.Capabilities.PanTiltRelative, angleValue(status.Tilt), angleRaw(status.Tilt), angleRange(status.Tilt))
+	writePTZRow(writer, "ZOOM", status.Capabilities.ZoomAbsolute, status.Capabilities.ZoomRelative, zoomValue(status.Zoom), zoomRaw(status.Zoom), zoomRange(status.Zoom))
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write PTZ table: %w", err)
+	}
+	return nil
+}
+
+func writePTZRow(writer io.Writer, control string, absolute, relative bool, value, raw string, valueRange *uvc.Range) {
+	minimum, maximum, resolution, defaultValue := "-", "-", "-", "-"
+	if valueRange != nil {
+		minimum = fmt.Sprint(valueRange.Min)
+		maximum = fmt.Sprint(valueRange.Max)
+		resolution = fmt.Sprint(valueRange.Res)
+		defaultValue = fmt.Sprint(valueRange.Def)
+	}
+	_, _ = fmt.Fprintf(writer, "%s\t%t\t%t\t%s\t%s\t%s\t%s\t%s\t%s\n", control, absolute, relative, value, raw, minimum, maximum, resolution, defaultValue)
+}
+
+func angleValue(status *ptzAngleOutput) string {
+	if status == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f°", status.Degrees)
+}
+
+func angleRaw(status *ptzAngleOutput) string {
+	if status == nil {
+		return "-"
+	}
+	return fmt.Sprint(status.Raw)
+}
+
+func angleRange(status *ptzAngleOutput) *uvc.Range {
+	if status == nil {
+		return nil
+	}
+	return &status.Range
+}
+
+func zoomValue(status *ptzZoomOutput) string {
+	if status == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f%%", status.Percent)
+}
+
+func zoomRaw(status *ptzZoomOutput) string {
+	if status == nil {
+		return "-"
+	}
+	return fmt.Sprint(status.Raw)
+}
+
+func zoomRange(status *ptzZoomOutput) *uvc.Range {
+	if status == nil {
+		return nil
+	}
+	return &status.Range
+}
+
+func addInt32(left, right int32) int32 {
+	sum := int64(left) + int64(right)
+	if sum > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if sum < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(sum)
+}

--- a/internal/cli/ptz_test.go
+++ b/internal/cli/ptz_test.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/steipete/camsnap/internal/uvc"
+)
+
+type fakePTZController struct {
+	capabilities uvc.Capabilities
+	status       uvc.Status
+	setPan       int32
+	setTilt      int32
+	setZoom      int32
+	panTiltSets  int
+	zoomSets     int
+	closed       bool
+}
+
+func (f *fakePTZController) Capabilities() uvc.Capabilities { return f.capabilities }
+func (f *fakePTZController) Status() (uvc.Status, error)    { return f.status, nil }
+func (f *fakePTZController) SetPanTilt(pan, tilt int32) (int32, int32, error) {
+	f.setPan = f.status.Pan.Range.Clamp(pan)
+	f.setTilt = f.status.Tilt.Range.Clamp(tilt)
+	f.status.Pan.Cur = f.setPan
+	f.status.Tilt.Cur = f.setTilt
+	f.panTiltSets++
+	return f.setPan, f.setTilt, nil
+}
+func (f *fakePTZController) SetZoom(zoom int32) (int32, error) {
+	f.setZoom = f.status.Zoom.Range.Clamp(zoom)
+	f.status.Zoom.Cur = f.setZoom
+	f.zoomSets++
+	return f.setZoom, nil
+}
+func (f *fakePTZController) Home() (uvc.Status, error) {
+	if f.status.Pan != nil {
+		f.status.Pan.Cur = f.status.Pan.Range.Def
+		f.status.Tilt.Cur = f.status.Tilt.Range.Def
+	}
+	if f.status.Zoom != nil {
+		f.status.Zoom.Cur = f.status.Zoom.Range.Def
+	}
+	return f.status, nil
+}
+func (f *fakePTZController) Close() error {
+	f.closed = true
+	return nil
+}
+
+func TestPTZMotionRequiresAnAxis(t *testing.T) {
+	tests := []string{"goto", "move"}
+	for _, subcommand := range tests {
+		t.Run(subcommand, func(t *testing.T) {
+			root := NewRootCommand("test")
+			root.SetArgs([]string{"ptz", subcommand})
+			err := root.Execute()
+			if err == nil || !strings.Contains(err.Error(), "at least one of --pan, --tilt, or --zoom is required") {
+				t.Fatalf("Execute error = %v", err)
+			}
+		})
+	}
+}
+
+func TestPTZMotionRejectsNonFiniteValues(t *testing.T) {
+	for _, value := range []string{"NaN", "+Inf", "-Inf"} {
+		root := NewRootCommand("test")
+		root.SetArgs([]string{"ptz", "goto", "--pan", value})
+		err := root.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--pan must be a finite number") {
+			t.Fatalf("Execute --pan %s error = %v", value, err)
+		}
+	}
+}
+
+func TestPTZCommandsRejectArguments(t *testing.T) {
+	tests := [][]string{
+		{"ptz", "status", "extra"},
+		{"ptz", "goto", "extra", "--pan", "1"},
+		{"ptz", "move", "extra", "--zoom", "1"},
+		{"ptz", "home", "extra"},
+	}
+	for _, args := range tests {
+		root := NewRootCommand("test")
+		root.SetArgs(args)
+		if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "unknown command") && !strings.Contains(err.Error(), "accepts 0 arg") {
+			t.Errorf("Execute(%v) error = %v", args, err)
+		}
+	}
+}
+
+func TestPTZGotoOnlyTouchesSpecifiedAxis(t *testing.T) {
+	controller := newFakePTZController()
+	restore := stubPTZBackend(t, controller)
+	defer restore()
+
+	root := NewRootCommand("test")
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"ptz", "goto", "--device", "Link", "--pan", "12.5", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if controller.setPan != 45000 || controller.setTilt != -7200 {
+		t.Fatalf("SetPanTilt = %d, %d, want 45000, -7200", controller.setPan, controller.setTilt)
+	}
+	if controller.panTiltSets != 1 || controller.zoomSets != 0 {
+		t.Fatalf("set counts = pan/tilt %d, zoom %d", controller.panTiltSets, controller.zoomSets)
+	}
+	if !controller.closed {
+		t.Fatal("controller was not closed")
+	}
+
+	var status ptzStatusOutput
+	if err := json.Unmarshal(output.Bytes(), &status); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, output.String())
+	}
+	if status.Pan == nil || status.Pan.Degrees != 12.5 {
+		t.Fatalf("pan output = %#v", status.Pan)
+	}
+}
+
+func TestPTZMoveZoomUsesPercentagePointDelta(t *testing.T) {
+	controller := newFakePTZController()
+	restore := stubPTZBackend(t, controller)
+	defer restore()
+
+	root := NewRootCommand("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"ptz", "move", "--zoom", "25"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if controller.setZoom != 400 {
+		t.Fatalf("SetZoom = %d, want 400", controller.setZoom)
+	}
+	if controller.panTiltSets != 0 || controller.zoomSets != 1 {
+		t.Fatalf("set counts = pan/tilt %d, zoom %d", controller.panTiltSets, controller.zoomSets)
+	}
+}
+
+func TestWritePTZStatusTable(t *testing.T) {
+	controller := newFakePTZController()
+	status := makePTZStatusOutput(
+		localDevice{ID: "camera-id", Name: "Insta360 Link", IsDefault: true},
+		controller.capabilities,
+		controller.status,
+	)
+	var output bytes.Buffer
+	if err := writePTZStatus(&output, false, status); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Device: Insta360 Link (camera-id)",
+		"CONTROL  ABSOLUTE  RELATIVE  VALUE",
+		"PAN      true      true      1.00°",
+		"TILT     true      true      -2.00°",
+		"ZOOM     true      true      50.00%",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("table missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestOpenPTZNamesUnsupportedCamera(t *testing.T) {
+	oldResolve := ptzResolveDevice
+	oldOpen := ptzOpenController
+	ptzResolveDevice = func(string) (localDevice, error) {
+		return localDevice{ID: "continuity-id", Name: "Continuity Camera"}, nil
+	}
+	ptzOpenController = func(string) (ptzController, error) {
+		return &fakePTZController{}, nil
+	}
+	t.Cleanup(func() {
+		ptzResolveDevice = oldResolve
+		ptzOpenController = oldOpen
+	})
+
+	_, _, err := openPTZ("")
+	if err == nil || !strings.Contains(err.Error(), `camera "Continuity Camera" does not advertise any UVC PTZ controls`) {
+		t.Fatalf("openPTZ error = %v", err)
+	}
+}
+
+func newFakePTZController() *fakePTZController {
+	panRange := uvc.Range{Min: -324000, Max: 324000, Res: 900, Def: 0}
+	tiltRange := uvc.Range{Min: -162000, Max: 162000, Res: 900, Def: 0}
+	zoomRange := uvc.Range{Min: 100, Max: 500, Res: 10, Def: 100}
+	return &fakePTZController{
+		capabilities: uvc.Capabilities{
+			PanTiltAbsolute: true,
+			PanTiltRelative: true,
+			ZoomAbsolute:    true,
+			ZoomRelative:    true,
+		},
+		status: uvc.Status{
+			Pan:  &uvc.AxisStatus{Cur: 3600, Range: panRange},
+			Tilt: &uvc.AxisStatus{Cur: -7200, Range: tiltRange},
+			Zoom: &uvc.AxisStatus{Cur: 300, Range: zoomRange},
+		},
+	}
+}
+
+func stubPTZBackend(t *testing.T, controller ptzController) func() {
+	t.Helper()
+	oldResolve := ptzResolveDevice
+	oldOpen := ptzOpenController
+	ptzResolveDevice = func(selector string) (localDevice, error) {
+		if selector != "" && selector != "Link" {
+			t.Fatalf("device selector = %q", selector)
+		}
+		return localDevice{ID: "camera-id", Index: "0", Name: "Insta360 Link", IsDefault: true}, nil
+	}
+	ptzOpenController = func(uniqueID string) (ptzController, error) {
+		if uniqueID != "camera-id" {
+			t.Fatalf("unique ID = %q", uniqueID)
+		}
+		return controller, nil
+	}
+	return func() {
+		ptzResolveDevice = oldResolve
+		ptzOpenController = oldOpen
+	}
+}

--- a/internal/cli/ptzbackend_darwin_cgo.go
+++ b/internal/cli/ptzbackend_darwin_cgo.go
@@ -1,0 +1,9 @@
+//go:build darwin && cgo
+
+package cli
+
+import "github.com/steipete/camsnap/internal/uvc"
+
+func openNativePTZController(uniqueID string) (ptzController, error) {
+	return uvc.Open(uniqueID)
+}

--- a/internal/cli/ptzbackend_stub.go
+++ b/internal/cli/ptzbackend_stub.go
@@ -1,0 +1,9 @@
+//go:build !darwin || !cgo
+
+package cli
+
+import "github.com/steipete/camsnap/internal/uvc"
+
+func openNativePTZController(string) (ptzController, error) {
+	return nil, uvc.ErrUnsupported
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,6 +31,7 @@ func NewRootCommand(version string) *cobra.Command {
 		newClipCmd(),
 		newDiscoverCmd(),
 		newDevicesCmd(),
+		newPTZCmd(),
 		newWatchCmd(),
 		newDoctorCmd(),
 		newVersionCmd(version),
@@ -53,6 +54,7 @@ func exampleText() string {
 	b.WriteString("  camsnap snap kitchen --out shot.jpg\n")
 	b.WriteString("  camsnap snap --device 0 --out webcam.jpg\n")
 	b.WriteString("  camsnap devices\n")
+	b.WriteString("  camsnap ptz status --device 0\n")
 	b.WriteString("  camsnap clip kitchen --dur 5s --no-audio --out clip.mp4\n")
 	b.WriteString("  camsnap watch kitchen --threshold 0.2 --cooldown 5s --json --action 'touch /tmp/motion'\n")
 	b.WriteString("  camsnap doctor --probe --rtsp-transport udp\n")

--- a/internal/uvc/bridge.h
+++ b/internal/uvc/bridge.h
@@ -1,0 +1,26 @@
+#ifndef CAMSNAP_UVC_BRIDGE_H
+#define CAMSNAP_UVC_BRIDGE_H
+
+#include <stdint.h>
+
+typedef struct UVCBridgeController UVCBridgeController;
+
+int uvc_open(
+    uint32_t location_id,
+    uint16_t vendor_id,
+    uint16_t product_id,
+    UVCBridgeController **controller_out,
+    uint32_t *controls_out,
+    char **error_out
+);
+int uvc_control(
+    UVCBridgeController *controller,
+    uint8_t selector,
+    uint8_t request,
+    void *data,
+    uint16_t length,
+    char **error_out
+);
+void uvc_close(UVCBridgeController *controller);
+
+#endif

--- a/internal/uvc/bridge.m
+++ b/internal/uvc/bridge.m
@@ -1,0 +1,362 @@
+#import "bridge.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <IOKit/IOCFPlugIn.h>
+#import <IOKit/IOKitLib.h>
+#import <IOKit/usb/IOUSBLib.h>
+#import <IOKit/usb/IOUSBHostFamilyDefinitions.h>
+
+#include <mach/mach_error.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+enum {
+    UVCVideoClass = 0x0e,
+    UVCVideoControlSubclass = 0x01,
+    UVCClassInterfaceDescriptor = 0x24,
+    UVCVideoControlHeader = 0x01,
+    UVCInputTerminal = 0x02,
+    UVCSetCurrent = 0x01,
+};
+
+struct UVCBridgeController {
+    IOUSBDeviceInterface **device;
+    IOUSBInterfaceInterface220 **interface;
+    uint8_t interface_number;
+    uint8_t terminal_id;
+    int interface_open;
+};
+
+static void UVCSetError(char **error_out, const char *format, ...) {
+    if (error_out == NULL) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, format);
+    if (vasprintf(error_out, format, args) < 0) {
+        *error_out = NULL;
+    }
+    va_end(args);
+}
+
+static uint32_t UVCNumberProperty(io_service_t service, CFStringRef key) {
+    CFTypeRef property = IORegistryEntryCreateCFProperty(service, key, kCFAllocatorDefault, 0);
+    if (property == NULL) {
+        return 0;
+    }
+
+    int64_t value = 0;
+    if (CFGetTypeID(property) == CFNumberGetTypeID()) {
+        CFNumberGetValue((CFNumberRef)property, kCFNumberSInt64Type, &value);
+    }
+    CFRelease(property);
+    return (uint32_t)value;
+}
+
+static IOUSBDeviceInterface **UVCCreateDeviceInterface(
+    uint32_t location_id,
+    uint16_t vendor_id,
+    uint16_t product_id,
+    IOReturn *failure_out
+) {
+    const char *class_names[] = {kIOUSBHostDeviceClassName, kIOUSBDeviceClassName};
+    IOReturn last_failure = kIOReturnNotFound;
+
+    for (size_t class_index = 0; class_index < sizeof(class_names) / sizeof(class_names[0]); class_index++) {
+        CFMutableDictionaryRef matching = IOServiceMatching(class_names[class_index]);
+        if (matching == NULL) {
+            continue;
+        }
+
+        io_iterator_t iterator = IO_OBJECT_NULL;
+        IOReturn result = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator);
+        if (result != kIOReturnSuccess) {
+            last_failure = result;
+            continue;
+        }
+
+        io_service_t service;
+        while ((service = IOIteratorNext(iterator)) != IO_OBJECT_NULL) {
+            uint32_t found_vendor = UVCNumberProperty(service, CFSTR(kUSBVendorID));
+            uint32_t found_product = UVCNumberProperty(service, CFSTR(kUSBProductID));
+            uint32_t found_location = UVCNumberProperty(service, CFSTR(kUSBDevicePropertyLocationID));
+            if (found_vendor != vendor_id || found_product != product_id || found_location != location_id) {
+                IOObjectRelease(service);
+                continue;
+            }
+
+            IOCFPlugInInterface **plugin = NULL;
+            SInt32 score = 0;
+            result = IOCreatePlugInInterfaceForService(
+                service,
+                kIOUSBDeviceUserClientTypeID,
+                kIOCFPlugInInterfaceID,
+                &plugin,
+                &score
+            );
+            IOObjectRelease(service);
+            if (result != kIOReturnSuccess || plugin == NULL) {
+                last_failure = result;
+                continue;
+            }
+
+            IOUSBDeviceInterface **device = NULL;
+            HRESULT query_result = (*plugin)->QueryInterface(
+                plugin,
+                CFUUIDGetUUIDBytes(kIOUSBDeviceInterfaceID),
+                (LPVOID *)&device
+            );
+            (*plugin)->Release(plugin);
+            if (query_result == S_OK && device != NULL) {
+                IOObjectRelease(iterator);
+                return device;
+            }
+            last_failure = (IOReturn)query_result;
+        }
+        IOObjectRelease(iterator);
+    }
+
+    if (failure_out != NULL) {
+        *failure_out = last_failure;
+    }
+    return NULL;
+}
+
+static void UVCReadTerminal(
+    IOUSBInterfaceInterface220 **interface,
+    uint8_t *terminal_id_out,
+    uint32_t *controls_out
+) {
+    *terminal_id_out = 1;
+    *controls_out = 0;
+
+    IOUSBDescriptorHeader *current = NULL;
+    const uint8_t *header = NULL;
+    while ((current = (*interface)->FindNextAssociatedDescriptor(
+                interface,
+                current,
+                UVCClassInterfaceDescriptor
+            )) != NULL) {
+        const uint8_t *bytes = (const uint8_t *)current;
+        if (bytes[0] >= 7 && bytes[2] == UVCVideoControlHeader) {
+            header = bytes;
+            break;
+        }
+    }
+    if (header == NULL) {
+        return;
+    }
+
+    size_t total_length = (size_t)header[5] | ((size_t)header[6] << 8);
+    for (size_t offset = 0; offset < total_length;) {
+        const uint8_t *descriptor = header + offset;
+        size_t length = descriptor[0];
+        if (length == 0 || offset + length > total_length) {
+            return;
+        }
+        if (length >= 15 && descriptor[1] == UVCClassInterfaceDescriptor && descriptor[2] == UVCInputTerminal) {
+            size_t control_size = descriptor[14];
+            if (15 + control_size > length) {
+                return;
+            }
+
+            uint32_t controls = 0;
+            for (size_t i = 0; i < control_size && i < sizeof(controls); i++) {
+                controls |= (uint32_t)descriptor[15 + i] << (8 * i);
+            }
+            if (descriptor[3] != 0) {
+                *terminal_id_out = descriptor[3];
+            }
+            *controls_out = controls;
+            return;
+        }
+        offset += length;
+    }
+}
+
+int uvc_open(
+    uint32_t location_id,
+    uint16_t vendor_id,
+    uint16_t product_id,
+    UVCBridgeController **controller_out,
+    uint32_t *controls_out,
+    char **error_out
+) {
+    if (controller_out == NULL || controls_out == NULL) {
+        UVCSetError(error_out, "invalid controller output pointers");
+        return 0;
+    }
+    *controller_out = NULL;
+    *controls_out = 0;
+
+    IOReturn result = kIOReturnSuccess;
+    IOUSBDeviceInterface **device = UVCCreateDeviceInterface(location_id, vendor_id, product_id, &result);
+    if (device == NULL) {
+        UVCSetError(
+            error_out,
+            "USB device %04x:%04x at location 0x%08x not found (%s, 0x%08x)",
+            vendor_id,
+            product_id,
+            location_id,
+            mach_error_string(result),
+            result
+        );
+        return 0;
+    }
+
+    IOUSBFindInterfaceRequest request = {
+        UVCVideoClass,
+        UVCVideoControlSubclass,
+        kIOUSBFindInterfaceDontCare,
+        kIOUSBFindInterfaceDontCare,
+    };
+    io_iterator_t iterator = IO_OBJECT_NULL;
+    result = (*device)->CreateInterfaceIterator(device, &request, &iterator);
+    if (result != kIOReturnSuccess) {
+        (*device)->Release(device);
+        UVCSetError(error_out, "find VideoControl interface: %s (0x%08x)", mach_error_string(result), result);
+        return 0;
+    }
+
+    io_service_t service = IOIteratorNext(iterator);
+    IOObjectRelease(iterator);
+    if (service == IO_OBJECT_NULL) {
+        (*device)->Release(device);
+        UVCSetError(error_out, "USB device has no UVC VideoControl interface");
+        return 0;
+    }
+
+    IOCFPlugInInterface **plugin = NULL;
+    SInt32 score = 0;
+    result = IOCreatePlugInInterfaceForService(
+        service,
+        kIOUSBInterfaceUserClientTypeID,
+        kIOCFPlugInInterfaceID,
+        &plugin,
+        &score
+    );
+    IOObjectRelease(service);
+    if (result != kIOReturnSuccess || plugin == NULL) {
+        (*device)->Release(device);
+        UVCSetError(error_out, "create VideoControl interface: %s (0x%08x)", mach_error_string(result), result);
+        return 0;
+    }
+
+    IOUSBInterfaceInterface220 **interface = NULL;
+    HRESULT query_result = (*plugin)->QueryInterface(
+        plugin,
+        CFUUIDGetUUIDBytes(kIOUSBInterfaceInterfaceID220),
+        (LPVOID *)&interface
+    );
+    (*plugin)->Release(plugin);
+    if (query_result != S_OK || interface == NULL) {
+        (*device)->Release(device);
+        UVCSetError(error_out, "query VideoControl interface: 0x%08x", (unsigned int)query_result);
+        return 0;
+    }
+
+    uint8_t interface_number = 0;
+    result = (*interface)->GetInterfaceNumber(interface, &interface_number);
+    if (result != kIOReturnSuccess) {
+        (*interface)->Release(interface);
+        (*device)->Release(device);
+        UVCSetError(error_out, "read VideoControl interface number: %s (0x%08x)", mach_error_string(result), result);
+        return 0;
+    }
+
+    int interface_open = 0;
+    result = (*interface)->USBInterfaceOpen(interface);
+    if (result == kIOReturnSuccess) {
+        interface_open = 1;
+    } else if (result != kIOReturnExclusiveAccess) {
+        (*interface)->Release(interface);
+        (*device)->Release(device);
+        UVCSetError(error_out, "open VideoControl interface: %s (0x%08x)", mach_error_string(result), result);
+        return 0;
+    }
+
+    UVCBridgeController *controller = calloc(1, sizeof(UVCBridgeController));
+    if (controller == NULL) {
+        if (interface_open) {
+            (*interface)->USBInterfaceClose(interface);
+        }
+        (*interface)->Release(interface);
+        (*device)->Release(device);
+        UVCSetError(error_out, "allocate UVC controller");
+        return 0;
+    }
+
+    controller->device = device;
+    controller->interface = interface;
+    controller->interface_number = interface_number;
+    controller->interface_open = interface_open;
+    UVCReadTerminal(interface, &controller->terminal_id, controls_out);
+    *controller_out = controller;
+    return 1;
+}
+
+int uvc_control(
+    UVCBridgeController *controller,
+    uint8_t selector,
+    uint8_t request,
+    void *data,
+    uint16_t length,
+    char **error_out
+) {
+    if (controller == NULL || controller->interface == NULL || data == NULL || length == 0) {
+        UVCSetError(error_out, "invalid control request");
+        return 0;
+    }
+
+    IOUSBDevRequest control_request = {
+        .bmRequestType = request == UVCSetCurrent ? 0x21 : 0xa1,
+        .bRequest = request,
+        .wValue = (uint16_t)selector << 8,
+        .wIndex = ((uint16_t)controller->terminal_id << 8) | controller->interface_number,
+        .wLength = length,
+        .pData = data,
+        .wLenDone = 0,
+    };
+    IOReturn result = (*controller->interface)->ControlRequest(controller->interface, 0, &control_request);
+    if (result != kIOReturnSuccess) {
+        UVCSetError(
+            error_out,
+            "control selector 0x%02x request 0x%02x: %s (0x%08x)",
+            selector,
+            request,
+            mach_error_string(result),
+            result
+        );
+        return 0;
+    }
+    if (control_request.wLenDone != length) {
+        UVCSetError(
+            error_out,
+            "control selector 0x%02x request 0x%02x transferred %u of %u bytes",
+            selector,
+            request,
+            control_request.wLenDone,
+            length
+        );
+        return 0;
+    }
+    return 1;
+}
+
+void uvc_close(UVCBridgeController *controller) {
+    if (controller == NULL) {
+        return;
+    }
+    if (controller->interface != NULL) {
+        if (controller->interface_open) {
+            (*controller->interface)->USBInterfaceClose(controller->interface);
+        }
+        (*controller->interface)->Release(controller->interface);
+    }
+    if (controller->device != NULL) {
+        (*controller->device)->Release(controller->device);
+    }
+    free(controller);
+}

--- a/internal/uvc/uvc.go
+++ b/internal/uvc/uvc.go
@@ -1,0 +1,226 @@
+// Package uvc controls pan/tilt/zoom on local USB UVC cameras.
+package uvc
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// UVC camera terminal control selectors (UVC 1.5, table A-12).
+const (
+	selZoomAbsolute    = 0x0B
+	selZoomRelative    = 0x0C
+	selPanTiltAbsolute = 0x0D
+	selPanTiltRelative = 0x0E
+)
+
+// UVC class-specific request codes (UVC 1.5, table A-8).
+const (
+	reqSetCur = 0x01
+	reqGetCur = 0x81
+	reqGetMin = 0x82
+	reqGetMax = 0x83
+	reqGetRes = 0x84
+	reqGetDef = 0x87
+)
+
+// Camera terminal bmControls bit positions (UVC 1.5, table 3-6).
+const (
+	ctrlBitZoomAbsolute    = 9
+	ctrlBitZoomRelative    = 10
+	ctrlBitPanTiltAbsolute = 11
+	ctrlBitPanTiltRelative = 12
+)
+
+const arcsecPerDegree = 3600
+
+const (
+	descriptorTypeClassInterface = 0x24
+	descriptorSubtypeVCHeader    = 0x01
+	descriptorSubtypeInputTerm   = 0x02
+)
+
+// ErrUnsupported reports that PTZ control is unavailable in this build.
+var ErrUnsupported = errors.New("uvc: PTZ control requires a cgo-enabled macOS build")
+
+// Capabilities lists the motion controls a camera advertises.
+type Capabilities struct {
+	PanTiltAbsolute bool `json:"pan_tilt_absolute"`
+	PanTiltRelative bool `json:"pan_tilt_relative"`
+	ZoomAbsolute    bool `json:"zoom_absolute"`
+	ZoomRelative    bool `json:"zoom_relative"`
+}
+
+// Any reports whether the camera advertises any PTZ control.
+func (c Capabilities) Any() bool {
+	return c.PanTiltAbsolute || c.PanTiltRelative || c.ZoomAbsolute || c.ZoomRelative
+}
+
+func capabilitiesFromControls(controls uint32) Capabilities {
+	return Capabilities{
+		PanTiltAbsolute: controls&(1<<ctrlBitPanTiltAbsolute) != 0,
+		PanTiltRelative: controls&(1<<ctrlBitPanTiltRelative) != 0,
+		ZoomAbsolute:    controls&(1<<ctrlBitZoomAbsolute) != 0,
+		ZoomRelative:    controls&(1<<ctrlBitZoomRelative) != 0,
+	}
+}
+
+// Range describes the values a control accepts in device units.
+type Range struct {
+	Min int32 `json:"min"`
+	Max int32 `json:"max"`
+	Res int32 `json:"res"`
+	Def int32 `json:"def"`
+}
+
+// Clamp bounds v to the range and snaps it to the control resolution.
+func (r Range) Clamp(v int32) int32 {
+	if r.Res > 1 {
+		steps := math.Round(float64(int64(v)-int64(r.Min)) / float64(r.Res))
+		snapped := int64(r.Min) + int64(steps)*int64(r.Res)
+		if snapped < int64(r.Min) {
+			return r.Min
+		}
+		if snapped > int64(r.Max) {
+			return r.Max
+		}
+		v = int32(snapped)
+	}
+	if v < r.Min {
+		return r.Min
+	}
+	if v > r.Max {
+		return r.Max
+	}
+	return v
+}
+
+// PercentOf maps a device-unit value to 0-100 across the range.
+func (r Range) PercentOf(v int32) float64 {
+	if r.Max <= r.Min {
+		return 0
+	}
+	v = r.Clamp(v)
+	return float64(int64(v)-int64(r.Min)) / float64(int64(r.Max)-int64(r.Min)) * 100
+}
+
+// FromPercent maps 0-100 to a clamped device-unit value.
+func (r Range) FromPercent(p float64) int32 {
+	if r.Max <= r.Min {
+		return r.Min
+	}
+	p = math.Max(0, math.Min(100, p))
+	v := float64(r.Min) + p/100*float64(int64(r.Max)-int64(r.Min))
+	return r.Clamp(int32(math.Round(v)))
+}
+
+// AxisStatus pairs a control's current value with its range.
+type AxisStatus struct {
+	Cur   int32 `json:"cur"`
+	Range Range `json:"range"`
+}
+
+// Status contains the current values and ranges for available absolute controls.
+type Status struct {
+	Pan  *AxisStatus `json:"pan,omitempty"`
+	Tilt *AxisStatus `json:"tilt,omitempty"`
+	Zoom *AxisStatus `json:"zoom,omitempty"`
+}
+
+// DegreesToArcsec converts degrees to the UVC pan/tilt wire unit.
+func DegreesToArcsec(deg float64) int32 {
+	if deg >= float64(math.MaxInt32)/arcsecPerDegree {
+		return math.MaxInt32
+	}
+	if deg <= float64(math.MinInt32)/arcsecPerDegree {
+		return math.MinInt32
+	}
+	return int32(math.Round(deg * arcsecPerDegree))
+}
+
+// ArcsecToDegrees converts the UVC pan/tilt wire unit to degrees.
+func ArcsecToDegrees(arcsec int32) float64 {
+	return float64(arcsec) / arcsecPerDegree
+}
+
+// ParseUSBUniqueID splits an AVFoundation unique ID such as
+// "0x21100002e1a4c06" into its USB location ID, vendor ID, and product ID.
+// AVFoundation builds these IDs as 0x<locationID><vendorID><productID>.
+func ParseUSBUniqueID(id string) (locationID uint32, vendorID, productID uint16, err error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(id), "0x")
+	if trimmed == "" || len(trimmed) > 16 {
+		return 0, 0, 0, fmt.Errorf("uvc: %q is not a USB camera unique ID", id)
+	}
+	value, parseErr := strconv.ParseUint(trimmed, 16, 64)
+	if parseErr != nil {
+		return 0, 0, 0, fmt.Errorf("uvc: %q is not a USB camera unique ID", id)
+	}
+	locationID = uint32(value >> 32)
+	if locationID == 0 {
+		return 0, 0, 0, fmt.Errorf("uvc: %q does not contain a USB location ID", id)
+	}
+	return locationID, uint16(value >> 16), uint16(value), nil
+}
+
+func encodePanTilt(pan, tilt int32) []byte {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(pan))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(tilt))
+	return buf
+}
+
+func decodePanTilt(buf []byte) (pan, tilt int32, err error) {
+	if len(buf) != 8 {
+		return 0, 0, fmt.Errorf("uvc: pan/tilt payload is %d bytes, want 8", len(buf))
+	}
+	pan = int32(binary.LittleEndian.Uint32(buf[0:4]))
+	tilt = int32(binary.LittleEndian.Uint32(buf[4:8]))
+	return pan, tilt, nil
+}
+
+func encodeZoom(v int32) []byte {
+	buf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buf, uint16(v))
+	return buf
+}
+
+func decodeZoom(buf []byte) (int32, error) {
+	if len(buf) != 2 {
+		return 0, fmt.Errorf("uvc: zoom payload is %d bytes, want 2", len(buf))
+	}
+	return int32(binary.LittleEndian.Uint16(buf)), nil
+}
+
+func parseCameraTerminalDescriptor(descriptors []byte) (unitID uint8, controls uint32, ok bool) {
+	if len(descriptors) < 7 || descriptors[0] < 7 || descriptors[1] != descriptorTypeClassInterface || descriptors[2] != descriptorSubtypeVCHeader {
+		return 0, 0, false
+	}
+
+	totalLength := int(binary.LittleEndian.Uint16(descriptors[5:7]))
+	if totalLength > len(descriptors) {
+		totalLength = len(descriptors)
+	}
+	for offset := 0; offset < totalLength; {
+		length := int(descriptors[offset])
+		if length == 0 || offset+length > totalLength {
+			return 0, 0, false
+		}
+		descriptor := descriptors[offset : offset+length]
+		if len(descriptor) >= 15 && descriptor[1] == descriptorTypeClassInterface && descriptor[2] == descriptorSubtypeInputTerm {
+			controlSize := int(descriptor[14])
+			if 15+controlSize > len(descriptor) {
+				return 0, 0, false
+			}
+			for i := 0; i < controlSize && i < 4; i++ {
+				controls |= uint32(descriptor[15+i]) << (8 * i)
+			}
+			return descriptor[3], controls, true
+		}
+		offset += length
+	}
+	return 0, 0, false
+}

--- a/internal/uvc/uvc_darwin_cgo.go
+++ b/internal/uvc/uvc_darwin_cgo.go
@@ -1,0 +1,315 @@
+//go:build darwin && cgo
+
+package uvc
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework IOKit -framework CoreFoundation
+#include <stdlib.h>
+#include "bridge.h"
+*/
+import "C"
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+// Controller controls the camera terminal of one USB UVC device.
+type Controller struct {
+	mu           sync.Mutex
+	handle       *C.UVCBridgeController
+	capabilities Capabilities
+}
+
+// Open finds the USB camera represented by an AVFoundation unique ID.
+func Open(uniqueID string) (*Controller, error) {
+	locationID, vendorID, productID, err := ParseUSBUniqueID(uniqueID)
+	if err != nil {
+		return nil, err
+	}
+
+	var handle *C.UVCBridgeController
+	var controls C.uint32_t
+	var cErr *C.char
+	if C.uvc_open(
+		C.uint32_t(locationID),
+		C.uint16_t(vendorID),
+		C.uint16_t(productID),
+		&handle,
+		&controls,
+		&cErr,
+	) == 0 {
+		return nil, bridgeError(cErr, "open USB camera")
+	}
+
+	controller := &Controller{
+		handle:       handle,
+		capabilities: capabilitiesFromControls(uint32(controls)),
+	}
+	runtime.SetFinalizer(controller, (*Controller).finalize)
+	return controller, nil
+}
+
+// Capabilities returns the PTZ controls advertised by the camera terminal.
+func (c *Controller) Capabilities() Capabilities {
+	if c == nil {
+		return Capabilities{}
+	}
+	return c.capabilities
+}
+
+// Status reads the current values and ranges of available absolute controls.
+func (c *Controller) Status() (Status, error) {
+	if c == nil {
+		return Status{}, fmt.Errorf("uvc: controller is nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.statusLocked()
+}
+
+// PanTiltRange reads the ranges for the paired absolute pan and tilt control.
+func (c *Controller) PanTiltRange() (pan, tilt Range, err error) {
+	if c == nil {
+		return Range{}, Range{}, fmt.Errorf("uvc: controller is nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.panTiltRangeLocked()
+}
+
+// ZoomRange reads the range for the absolute zoom control.
+func (c *Controller) ZoomRange() (Range, error) {
+	if c == nil {
+		return Range{}, fmt.Errorf("uvc: controller is nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.zoomRangeLocked()
+}
+
+// SetPanTilt clamps and writes the paired absolute pan and tilt values.
+func (c *Controller) SetPanTilt(pan, tilt int32) (appliedPan, appliedTilt int32, err error) {
+	if c == nil {
+		return 0, 0, fmt.Errorf("uvc: controller is nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	panRange, tiltRange, err := c.panTiltRangeLocked()
+	if err != nil {
+		return 0, 0, err
+	}
+	appliedPan = panRange.Clamp(pan)
+	appliedTilt = tiltRange.Clamp(tilt)
+	if err := c.controlLocked(selPanTiltAbsolute, reqSetCur, encodePanTilt(appliedPan, appliedTilt)); err != nil {
+		return 0, 0, err
+	}
+	return appliedPan, appliedTilt, nil
+}
+
+// SetZoom clamps and writes an absolute zoom value.
+func (c *Controller) SetZoom(zoom int32) (int32, error) {
+	if c == nil {
+		return 0, fmt.Errorf("uvc: controller is nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	zoomRange, err := c.zoomRangeLocked()
+	if err != nil {
+		return 0, err
+	}
+	applied := zoomRange.Clamp(zoom)
+	if err := c.controlLocked(selZoomAbsolute, reqSetCur, encodeZoom(applied)); err != nil {
+		return 0, err
+	}
+	return applied, nil
+}
+
+// Home resets available absolute controls to their advertised defaults.
+func (c *Controller) Home() (Status, error) {
+	if c == nil {
+		return Status{}, fmt.Errorf("uvc: controller is nil")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.capabilities.PanTiltAbsolute && !c.capabilities.ZoomAbsolute {
+		return Status{}, fmt.Errorf("uvc: camera has no absolute PTZ controls")
+	}
+	if c.capabilities.PanTiltAbsolute {
+		panRange, tiltRange, err := c.panTiltRangeLocked()
+		if err != nil {
+			return Status{}, err
+		}
+		if err := c.controlLocked(selPanTiltAbsolute, reqSetCur, encodePanTilt(panRange.Def, tiltRange.Def)); err != nil {
+			return Status{}, err
+		}
+	}
+	if c.capabilities.ZoomAbsolute {
+		zoomRange, err := c.zoomRangeLocked()
+		if err != nil {
+			return Status{}, err
+		}
+		if err := c.controlLocked(selZoomAbsolute, reqSetCur, encodeZoom(zoomRange.Def)); err != nil {
+			return Status{}, err
+		}
+	}
+	return c.statusLocked()
+}
+
+// Close releases the IOKit interfaces held by the controller.
+func (c *Controller) Close() error {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.handle != nil {
+		C.uvc_close(c.handle)
+		c.handle = nil
+	}
+	runtime.SetFinalizer(c, nil)
+	return nil
+}
+
+func (c *Controller) finalize() {
+	_ = c.Close()
+}
+
+func (c *Controller) statusLocked() (Status, error) {
+	if err := c.ensureOpenLocked(); err != nil {
+		return Status{}, err
+	}
+
+	var status Status
+	if c.capabilities.PanTiltAbsolute {
+		panRange, tiltRange, err := c.panTiltRangeLocked()
+		if err != nil {
+			return Status{}, err
+		}
+		pan, tilt, err := c.panTiltLocked(reqGetCur)
+		if err != nil {
+			return Status{}, err
+		}
+		status.Pan = &AxisStatus{Cur: pan, Range: panRange}
+		status.Tilt = &AxisStatus{Cur: tilt, Range: tiltRange}
+	}
+	if c.capabilities.ZoomAbsolute {
+		zoomRange, err := c.zoomRangeLocked()
+		if err != nil {
+			return Status{}, err
+		}
+		zoom, err := c.zoomLocked(reqGetCur)
+		if err != nil {
+			return Status{}, err
+		}
+		status.Zoom = &AxisStatus{Cur: zoom, Range: zoomRange}
+	}
+	return status, nil
+}
+
+func (c *Controller) panTiltRangeLocked() (Range, Range, error) {
+	if !c.capabilities.PanTiltAbsolute {
+		return Range{}, Range{}, fmt.Errorf("uvc: camera does not support absolute pan/tilt")
+	}
+	minPan, minTilt, err := c.panTiltLocked(reqGetMin)
+	if err != nil {
+		return Range{}, Range{}, err
+	}
+	maxPan, maxTilt, err := c.panTiltLocked(reqGetMax)
+	if err != nil {
+		return Range{}, Range{}, err
+	}
+	resPan, resTilt, err := c.panTiltLocked(reqGetRes)
+	if err != nil {
+		return Range{}, Range{}, err
+	}
+	defPan, defTilt, err := c.panTiltLocked(reqGetDef)
+	if err != nil {
+		defPan, defTilt = 0, 0
+	}
+	pan := Range{Min: minPan, Max: maxPan, Res: resPan}
+	tilt := Range{Min: minTilt, Max: maxTilt, Res: resTilt}
+	pan.Def = pan.Clamp(defPan)
+	tilt.Def = tilt.Clamp(defTilt)
+	return pan, tilt, nil
+}
+
+func (c *Controller) zoomRangeLocked() (Range, error) {
+	if !c.capabilities.ZoomAbsolute {
+		return Range{}, fmt.Errorf("uvc: camera does not support absolute zoom")
+	}
+	minimum, err := c.zoomLocked(reqGetMin)
+	if err != nil {
+		return Range{}, err
+	}
+	maximum, err := c.zoomLocked(reqGetMax)
+	if err != nil {
+		return Range{}, err
+	}
+	res, err := c.zoomLocked(reqGetRes)
+	if err != nil {
+		return Range{}, err
+	}
+	def, err := c.zoomLocked(reqGetDef)
+	if err != nil {
+		def = minimum
+	}
+	zoomRange := Range{Min: minimum, Max: maximum, Res: res}
+	zoomRange.Def = zoomRange.Clamp(def)
+	return zoomRange, nil
+}
+
+func (c *Controller) panTiltLocked(request byte) (int32, int32, error) {
+	buf := make([]byte, 8)
+	if err := c.controlLocked(selPanTiltAbsolute, request, buf); err != nil {
+		return 0, 0, err
+	}
+	return decodePanTilt(buf)
+}
+
+func (c *Controller) zoomLocked(request byte) (int32, error) {
+	buf := make([]byte, 2)
+	if err := c.controlLocked(selZoomAbsolute, request, buf); err != nil {
+		return 0, err
+	}
+	return decodeZoom(buf)
+}
+
+func (c *Controller) controlLocked(selector, request byte, data []byte) error {
+	if err := c.ensureOpenLocked(); err != nil {
+		return err
+	}
+	var cErr *C.char
+	if C.uvc_control(
+		c.handle,
+		C.uint8_t(selector),
+		C.uint8_t(request),
+		unsafe.Pointer(&data[0]),
+		C.uint16_t(len(data)),
+		&cErr,
+	) == 0 {
+		return bridgeError(cErr, "perform camera control request")
+	}
+	return nil
+}
+
+func (c *Controller) ensureOpenLocked() error {
+	if c.handle == nil {
+		return fmt.Errorf("uvc: controller is closed")
+	}
+	return nil
+}
+
+func bridgeError(cErr *C.char, fallback string) error {
+	if cErr == nil {
+		return fmt.Errorf("uvc: %s", fallback)
+	}
+	defer C.free(unsafe.Pointer(cErr))
+	return fmt.Errorf("uvc: %s", C.GoString(cErr))
+}

--- a/internal/uvc/uvc_stub.go
+++ b/internal/uvc/uvc_stub.go
@@ -1,0 +1,33 @@
+//go:build !darwin || !cgo
+
+package uvc
+
+// Controller is unavailable outside cgo-enabled macOS builds.
+type Controller struct{}
+
+// Open reports that UVC control is unavailable in this build.
+func Open(string) (*Controller, error) { return nil, ErrUnsupported }
+
+// Capabilities returns no available controls in an unsupported build.
+func (*Controller) Capabilities() Capabilities { return Capabilities{} }
+
+// Status reports that UVC control is unavailable in this build.
+func (*Controller) Status() (Status, error) { return Status{}, ErrUnsupported }
+
+// PanTiltRange reports that UVC control is unavailable in this build.
+func (*Controller) PanTiltRange() (Range, Range, error) { return Range{}, Range{}, ErrUnsupported }
+
+// ZoomRange reports that UVC control is unavailable in this build.
+func (*Controller) ZoomRange() (Range, error) { return Range{}, ErrUnsupported }
+
+// SetPanTilt reports that UVC control is unavailable in this build.
+func (*Controller) SetPanTilt(int32, int32) (int32, int32, error) { return 0, 0, ErrUnsupported }
+
+// SetZoom reports that UVC control is unavailable in this build.
+func (*Controller) SetZoom(int32) (int32, error) { return 0, ErrUnsupported }
+
+// Home reports that UVC control is unavailable in this build.
+func (*Controller) Home() (Status, error) { return Status{}, ErrUnsupported }
+
+// Close is a no-op in an unsupported build.
+func (*Controller) Close() error { return nil }

--- a/internal/uvc/uvc_test.go
+++ b/internal/uvc/uvc_test.go
@@ -1,0 +1,163 @@
+package uvc
+
+import (
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRange(t *testing.T) {
+	t.Parallel()
+
+	r := Range{Min: 100, Max: 500, Res: 20, Def: 100}
+	tests := []struct {
+		name        string
+		value       int32
+		wantClamped int32
+		wantPercent float64
+	}{
+		{name: "minimum", value: 0, wantClamped: 100, wantPercent: 0},
+		{name: "snaps down", value: 149, wantClamped: 140, wantPercent: 10},
+		{name: "snaps up", value: 151, wantClamped: 160, wantPercent: 15},
+		{name: "maximum", value: 900, wantClamped: 500, wantPercent: 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := r.Clamp(tt.value); got != tt.wantClamped {
+				t.Fatalf("Clamp(%d) = %d, want %d", tt.value, got, tt.wantClamped)
+			}
+			if got := r.PercentOf(tt.value); got != tt.wantPercent {
+				t.Fatalf("PercentOf(%d) = %v, want %v", tt.value, got, tt.wantPercent)
+			}
+		})
+	}
+
+	percentTests := []struct {
+		percent float64
+		want    int32
+	}{
+		{percent: -10, want: 100},
+		{percent: 25, want: 200},
+		{percent: 100, want: 500},
+		{percent: 125, want: 500},
+	}
+	for _, tt := range percentTests {
+		if got := r.FromPercent(tt.percent); got != tt.want {
+			t.Errorf("FromPercent(%v) = %d, want %d", tt.percent, got, tt.want)
+		}
+	}
+}
+
+func TestDegreesArcsecondsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, degrees := range []float64{-42.25, 0, 12.5, 90} {
+		arcseconds := DegreesToArcsec(degrees)
+		if got := ArcsecToDegrees(arcseconds); got != degrees {
+			t.Errorf("ArcsecToDegrees(DegreesToArcsec(%v)) = %v", degrees, got)
+		}
+	}
+	if got := DegreesToArcsec(math.MaxFloat64); got != math.MaxInt32 {
+		t.Fatalf("DegreesToArcsec(MaxFloat64) = %d, want %d", got, int32(math.MaxInt32))
+	}
+}
+
+func TestParseUSBUniqueID(t *testing.T) {
+	t.Parallel()
+
+	locationID, vendorID, productID, err := ParseUSBUniqueID("0x21100002e1a4c06")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if locationID != 0x02110000 || vendorID != 0x2e1a || productID != 0x4c06 {
+		t.Fatalf("ParseUSBUniqueID = %#x, %#x, %#x", locationID, vendorID, productID)
+	}
+
+	for _, id := range []string{"", "not-hex", "0x2e1a4c06", "0x1234567890abcdef0"} {
+		if _, _, _, err := ParseUSBUniqueID(id); err == nil || !strings.Contains(err.Error(), "USB camera unique ID") && !strings.Contains(err.Error(), "USB location ID") {
+			t.Errorf("ParseUSBUniqueID(%q) error = %v", id, err)
+		}
+	}
+}
+
+func TestPanTiltEncoding(t *testing.T) {
+	t.Parallel()
+
+	want := []byte{0xc0, 0x1d, 0xfe, 0xff, 0xa0, 0x8c, 0x00, 0x00}
+	encoded := encodePanTilt(-123456, 36000)
+	if !reflect.DeepEqual(encoded, want) {
+		t.Fatalf("encodePanTilt = % x, want % x", encoded, want)
+	}
+	pan, tilt, err := decodePanTilt(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pan != -123456 || tilt != 36000 {
+		t.Fatalf("decodePanTilt = %d, %d", pan, tilt)
+	}
+	if _, _, err := decodePanTilt(make([]byte, 7)); err == nil {
+		t.Fatal("decodePanTilt accepted a short payload")
+	}
+}
+
+func TestZoomEncoding(t *testing.T) {
+	t.Parallel()
+
+	want := []byte{0x34, 0x12}
+	encoded := encodeZoom(0x1234)
+	if !reflect.DeepEqual(encoded, want) {
+		t.Fatalf("encodeZoom = % x, want % x", encoded, want)
+	}
+	zoom, err := decodeZoom(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if zoom != 0x1234 {
+		t.Fatalf("decodeZoom = %#x", zoom)
+	}
+	if _, err := decodeZoom(make([]byte, 1)); err == nil {
+		t.Fatal("decodeZoom accepted a short payload")
+	}
+}
+
+func TestParseCameraTerminalDescriptor(t *testing.T) {
+	t.Parallel()
+
+	// Synthetic VideoControl descriptor block: header, output terminal, then a
+	// camera input terminal with three bmControls bytes.
+	descriptors := []byte{
+		13, 0x24, 0x01, 0x50, 0x01, 40, 0, 0, 0, 0, 0, 0, 0,
+		9, 0x24, 0x03, 2, 0x01, 0x01, 0, 1, 0,
+		18, 0x24, 0x02, 5, 0x01, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0x00, 0x1a, 0x00,
+	}
+	unitID, controls, ok := parseCameraTerminalDescriptor(descriptors)
+	if !ok {
+		t.Fatal("parseCameraTerminalDescriptor did not find the input terminal")
+	}
+	if unitID != 5 || controls != 0x1a00 {
+		t.Fatalf("parseCameraTerminalDescriptor = %d, %#x", unitID, controls)
+	}
+	capabilities := capabilitiesFromControls(controls)
+	want := Capabilities{PanTiltAbsolute: true, PanTiltRelative: true, ZoomAbsolute: true, ZoomRelative: false}
+	if capabilities != want {
+		t.Fatalf("capabilities = %#v, want %#v", capabilities, want)
+	}
+}
+
+func TestParseCameraTerminalDescriptorRejectsMalformedData(t *testing.T) {
+	t.Parallel()
+
+	tests := [][]byte{
+		nil,
+		{0, 0x24, 0x01, 0, 0, 7, 0},
+		{7, 0x24, 0x01, 0, 0, 8, 0, 0},
+		{7, 0x24, 0x01, 0, 0, 20, 0, 18, 0x24, 0x02},
+	}
+	for _, descriptors := range tests {
+		if _, _, ok := parseCameraTerminalDescriptor(descriptors); ok {
+			t.Errorf("parseCameraTerminalDescriptor(% x) succeeded", descriptors)
+		}
+	}
+}


### PR DESCRIPTION
Adds a `camsnap ptz` command group that moves PTZ-capable USB webcams (pan/tilt/zoom) on macOS via standard UVC camera-terminal controls over a cgo IOKit bridge.

## API

```
camsnap ptz status [--device X] [--json]
camsnap ptz goto   [--device X] [--pan DEG] [--tilt DEG] [--zoom PCT]
camsnap ptz move   [--device X] [--pan DEG] [--tilt DEG] [--zoom PCT]   # relative deltas
camsnap ptz home   [--device X]
```

- Pan/tilt in degrees (UVC wire format is arc-seconds, spec-defined, portable across cameras); zoom as percent of the device range (raw zoom units are device-defined).
- `--device` accepts the same index/ID/name selectors as `snap --device`; defaults to the default camera.
- Values clamp and snap to the ranges the camera advertises; commands print the positions actually applied.
- Relative moves are read-modify-write on the absolute controls (native UVC relative-speed controls vary wildly between devices; Insta360 does not even advertise relative zoom).
- Works while another app streams from the camera: on `kIOReturnExclusiveAccess` the bridge skips `USBInterfaceOpen` and issues control requests on the default pipe, which macOS permits.

## Design notes

- New `internal/uvc` package mirrors the `internal/avf` pattern: pure-Go core (wire encoding, range math, descriptor parsing — all unit-tested), cgo IOKit bridge behind `darwin && cgo`, stub elsewhere. `CGO_ENABLED=0` builds keep working.
- The camera-terminal unit ID and capability bitmap are parsed from the VideoControl class descriptor instead of hardcoding terminal ID 1 (an improvement over uvc-util, which hardcodes it).
- AVFoundation unique IDs (`0x21100002e1a4c06`) pack USB locationID|vendorID|productID, so device resolution maps deterministically onto the USB registry.

## Proof (real hardware: Insta360 Link 2 Pro)

```
$ ./camsnap ptz status --device "Insta360 Link 2 Pro"
Device: Insta360 Link 2 Pro (0x21100002e1a4c06)
CONTROL  ABSOLUTE  RELATIVE  VALUE    RAW      MIN      MAX     RES   DEFAULT
PAN      true      true      -0.20    -720     -522000  522000  3600  0
TILT     true      true      -85.00   -306000  -324000  360000  3600  0
ZOOM     true      false     0.00     100      100      400     1     100

$ ./camsnap ptz goto --device 0 --pan 30 --tilt 10 --zoom 50   # camera physically moved
PAN 30.00 / TILT 10.00 / ZOOM 50.00 applied

$ ./camsnap ptz move --device 0 --pan -15 --zoom -25           # relative: pan 30->15, zoom 50->0 (clamped floor)
$ ./camsnap ptz home --device 0                                # returns to 0/0/min zoom
```

`make all` green (fmt, golangci-lint 0 issues, all tests pass). `CGO_ENABLED=0 go build ./...` passes. Codex autoreview clean (no P0 findings, confidence 0.97).
