### PR TITLE
fix(ptz): verify camera motion through a fresh control connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.4.1 - Unreleased
+- Keep UVC PTZ cameras streaming during control, verify settled positions through fresh connections, and add configurable motion timing.
 
 ## 0.4.0 - 2026-08-06
 - Add pan, tilt, zoom, status, and home controls for UVC USB cameras on macOS.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ camsnap ptz status --device 0
 camsnap ptz goto --device 0 --pan 12.5 --tilt -5 --zoom 50
 camsnap ptz move --device 0 --pan -10 --zoom 5
 camsnap ptz home --device 0
+camsnap ptz goto --device 0 --pan 45 --settle 3s --timeout 6s
 ```
+
+PTZ commands keep the selected camera streaming while reading or changing its position, so they require macOS Camera permission. Motion commands verify the observed position after `--settle` (default `2s`) and fail if it does not stabilize before `--timeout` (default `5s`).
 
 See [Local webcams](docs/local-webcams.md) for stable macOS device selectors, Camera permission behavior, UVC PTZ control, Linux device paths, and backend selection.
 

--- a/docs/local-webcams.md
+++ b/docs/local-webcams.md
@@ -61,9 +61,14 @@ camsnap ptz status --device 0
 camsnap ptz goto --device 0 --pan 12.5 --tilt -5 --zoom 50
 camsnap ptz move --device 0 --pan -10 --zoom 5
 camsnap ptz home --device 0
+camsnap ptz goto --device 0 --pan 45 --settle 3s --timeout 6s
 ```
 
-`goto` uses absolute pan and tilt angles in degrees and zoom from 0–100 percent. `move` takes degree deltas and zoom percentage-point deltas. Values are clamped and snapped to the ranges reported by the camera, and the command prints the positions actually applied. `home` uses each control's UVC default, falling back to zero pan/tilt and minimum zoom when a device does not report defaults. Every subcommand supports `--json`.
+Some gimbal webcams service UVC controls only while their video stream is active: without a stream, position reads can be stale and accepted movement commands can be silently ignored. Every `ptz` subcommand starts a temporary AVFoundation capture session before accessing UVC, keeps the stream active throughout the operation, and stops it afterward without saving a frame. This requires the same macOS Camera permission as native snapshots.
+
+`goto` uses absolute pan and tilt angles in degrees and zoom from 0–100 percent. `move` takes degree deltas and zoom percentage-point deltas. Values are clamped and snapped to the ranges reported by the camera, and the command prints the observed positions after they stabilize. `home` uses each control's UVC default, falling back to zero pan/tilt and minimum zoom when a device does not report defaults. Every subcommand supports `--json`.
+
+The motion commands accept `--settle` (default `2s`) to give the gimbal time to reach its target and `--timeout` (default `5s`) for the overall verification wait. Verification uses a fresh UVC connection that never issued the movement command, because the original connection can echo an uncommitted setpoint even when the camera did not move. If the observed position differs from the requested target by more than the camera's reported control resolution, the command fails. Confirm that the camera can stream and disable any on-camera AI framing or tracking that overrides manual positioning before retrying.
 
 The status table shows raw UVC ranges: pan and tilt use arcseconds, while zoom units are device-specific. Relative moves are implemented as a current-position read followed by a clamped absolute write because native UVC relative-speed controls vary between devices.
 

--- a/internal/avf/avf.go
+++ b/internal/avf/avf.go
@@ -31,6 +31,12 @@ type Device struct {
 	IsDefault bool
 }
 
+// Session keeps a camera's video stream active without saving any frames.
+type Session struct {
+	mu     sync.Mutex
+	handle unsafe.Pointer
+}
+
 var (
 	accessSequence atomic.Uint64
 	accessMu       sync.Mutex
@@ -101,6 +107,40 @@ func RequestAccess(ctx context.Context) (bool, error) {
 	case <-ctx.Done():
 		return false, ctx.Err()
 	}
+}
+
+// OpenSession starts a video capture session for deviceID and waits for its
+// first frame. An empty deviceID selects the default camera.
+func OpenSession(deviceID string) (*Session, error) {
+	cDeviceID := C.CString(deviceID)
+	defer C.free(unsafe.Pointer(cDeviceID))
+
+	var cErr *C.char
+	handle := C.avf_open_session(cDeviceID, &cErr)
+	if handle == nil {
+		return nil, bridgeError(cErr, "open capture session")
+	}
+	return &Session{handle: handle}, nil
+}
+
+// Close stops the video capture session and releases its camera resources.
+func (s *Session) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.handle == nil {
+		return nil
+	}
+
+	handle := s.handle
+	s.handle = nil
+	var cErr *C.char
+	if C.avf_close_session(handle, &cErr) == 0 {
+		return bridgeError(cErr, "close capture session")
+	}
+	return nil
 }
 
 // CaptureFrame starts a capture session for deviceID and writes one JPEG frame

--- a/internal/avf/bridge.h
+++ b/internal/avf/bridge.h
@@ -15,6 +15,8 @@ void avf_free_devices(AVFDevice *devices, size_t count);
 int avf_authorization_status(void);
 int avf_request_access(unsigned long long token, char **error_out);
 
+void *avf_open_session(const char *device_id, char **error_out);
+int avf_close_session(void *session, char **error_out);
 int avf_capture_frame(const char *device_id, double warmup_seconds, const char *out_path, char **error_out);
 
 extern void goAVFAccessResult(unsigned long long token, int granted);

--- a/internal/avf/bridge.m
+++ b/internal/avf/bridge.m
@@ -233,6 +233,55 @@ int avf_request_access(unsigned long long token, char **error_out) {
 
 @end
 
+@interface AVFStreamSession : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate>
+
+@property(nonatomic, readonly) AVCaptureSession *session;
+@property(nonatomic, readonly) dispatch_semaphore_t semaphore;
+
+- (instancetype)initWithSession:(AVCaptureSession *)session output:(AVCaptureVideoDataOutput *)output;
+- (void)stop;
+
+@end
+
+@implementation AVFStreamSession {
+    AVCaptureVideoDataOutput *_output;
+    dispatch_queue_t _queue;
+    BOOL _received_frame;
+}
+
+- (instancetype)initWithSession:(AVCaptureSession *)session output:(AVCaptureVideoDataOutput *)output {
+    self = [super init];
+    if (self != nil) {
+        _session = session;
+        _output = output;
+        _queue = dispatch_queue_create("com.steipete.camsnap.avf.stream", DISPATCH_QUEUE_SERIAL);
+        _semaphore = dispatch_semaphore_create(0);
+        [_output setSampleBufferDelegate:self queue:_queue];
+    }
+    return self;
+}
+
+- (void)captureOutput:(AVCaptureOutput *)output
+    didOutputSampleBuffer:(CMSampleBufferRef)sample_buffer
+           fromConnection:(AVCaptureConnection *)connection {
+    (void)output;
+    (void)sample_buffer;
+    (void)connection;
+
+    if (!_received_frame) {
+        _received_frame = YES;
+        dispatch_semaphore_signal(_semaphore);
+    }
+}
+
+- (void)stop {
+    [_session stopRunning];
+    [_output setSampleBufferDelegate:nil queue:NULL];
+    dispatch_sync(_queue, ^{});
+}
+
+@end
+
 static AVCaptureDevice *AVFFindDevice(const char *device_id) {
     if (device_id == NULL || device_id[0] == '\0') {
         return [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
@@ -247,25 +296,113 @@ static AVCaptureDevice *AVFFindDevice(const char *device_id) {
     return nil;
 }
 
+static BOOL AVFCheckAuthorization(char **error_out) {
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    if (status == AVAuthorizationStatusAuthorized) {
+        return YES;
+    }
+
+    NSString *status_name = @"unknown";
+    switch (status) {
+        case AVAuthorizationStatusNotDetermined:
+            status_name = @"notDetermined";
+            break;
+        case AVAuthorizationStatusRestricted:
+            status_name = @"restricted";
+            break;
+        case AVAuthorizationStatusDenied:
+            status_name = @"denied";
+            break;
+        case AVAuthorizationStatusAuthorized:
+            break;
+    }
+    AVFSetError(error_out, [NSString stringWithFormat:@"camera access is %@", status_name]);
+    return NO;
+}
+
+void *avf_open_session(const char *device_id, char **error_out) {
+    @autoreleasepool {
+        if (!AVFCheckAuthorization(error_out)) {
+            return NULL;
+        }
+
+        @try {
+            AVCaptureDevice *device = AVFFindDevice(device_id);
+            if (device == nil) {
+                AVFSetError(error_out, device_id == NULL || device_id[0] == '\0'
+                    ? @"no default video capture device"
+                    : @"video capture device not found");
+                return NULL;
+            }
+
+            NSError *input_error = nil;
+            AVCaptureDeviceInput *input = [AVCaptureDeviceInput deviceInputWithDevice:device error:&input_error];
+            if (input == nil) {
+                AVFSetError(error_out, [NSString stringWithFormat:@"create device input: %@", input_error.localizedDescription]);
+                return NULL;
+            }
+
+            AVCaptureSession *session = [[AVCaptureSession alloc] init];
+            AVCaptureVideoDataOutput *output = [[AVCaptureVideoDataOutput alloc] init];
+            output.alwaysDiscardsLateVideoFrames = YES;
+            output.videoSettings = @{
+                (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32BGRA),
+            };
+
+            [session beginConfiguration];
+            if (![session canAddInput:input]) {
+                [session commitConfiguration];
+                AVFSetError(error_out, @"capture session rejected device input");
+                return NULL;
+            }
+            [session addInput:input];
+            if (![session canAddOutput:output]) {
+                [session commitConfiguration];
+                AVFSetError(error_out, @"capture session rejected video output");
+                return NULL;
+            }
+            [session addOutput:output];
+            [session commitConfiguration];
+
+            AVFStreamSession *stream = [[AVFStreamSession alloc] initWithSession:session output:output];
+            [session startRunning];
+            long wait_result = dispatch_semaphore_wait(
+                stream.semaphore,
+                dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC)
+            );
+            if (wait_result != 0) {
+                [stream stop];
+                AVFSetError(error_out, @"timed out waiting for a video frame");
+                return NULL;
+            }
+            return (__bridge_retained void *)stream;
+        } @catch (NSException *exception) {
+            AVFSetError(error_out, [NSString stringWithFormat:@"open capture session: %@", exception.reason]);
+            return NULL;
+        }
+    }
+}
+
+int avf_close_session(void *session, char **error_out) {
+    @autoreleasepool {
+        if (session == NULL) {
+            return 1;
+        }
+
+        AVFStreamSession *stream = (__bridge_transfer AVFStreamSession *)session;
+        @try {
+            [stream stop];
+            return 1;
+        } @catch (NSException *exception) {
+            AVFSetError(error_out, [NSString stringWithFormat:@"close capture session: %@", exception.reason]);
+            return 0;
+        }
+    }
+}
+
 int avf_capture_frame(const char *device_id, double warmup_seconds, const char *out_path, char **error_out) {
     @autoreleasepool {
-        AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
-        if (status != AVAuthorizationStatusAuthorized) {
-            NSString *status_name = @"unknown";
-            switch (status) {
-                case AVAuthorizationStatusNotDetermined:
-                    status_name = @"notDetermined";
-                    break;
-                case AVAuthorizationStatusRestricted:
-                    status_name = @"restricted";
-                    break;
-                case AVAuthorizationStatusDenied:
-                    status_name = @"denied";
-                    break;
-                case AVAuthorizationStatusAuthorized:
-                    break;
-            }
-            AVFSetError(error_out, [NSString stringWithFormat:@"camera access is %@", status_name]);
+        if (!AVFCheckAuthorization(error_out)) {
             return 0;
         }
 

--- a/internal/avf/bridge.m
+++ b/internal/avf/bridge.m
@@ -1,3 +1,5 @@
+//go:build darwin && cgo
+
 #import "bridge.h"
 
 #import <AVFoundation/AVFoundation.h>

--- a/internal/cli/ptz.go
+++ b/internal/cli/ptz.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math"
+	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steipete/camsnap/internal/uvc"
@@ -23,6 +26,16 @@ type ptzController interface {
 type ptzOptions struct {
 	device     string
 	jsonOutput bool
+}
+
+type ptzMotionOptions struct {
+	settle  time.Duration
+	timeout time.Duration
+}
+
+type ptzTarget struct {
+	pan, tilt, zoom                int32
+	checkPan, checkTilt, checkZoom bool
 }
 
 type ptzAngleOutput struct {
@@ -47,8 +60,13 @@ type ptzStatusOutput struct {
 
 var (
 	ptzResolveDevice  = resolveNativePTZDevice
+	ptzOpenSession    = openNativePTZSession
 	ptzOpenController = openNativePTZController
+	ptzNow            = time.Now
+	ptzSleep          = time.Sleep
 )
+
+const ptzPollInterval = 100 * time.Millisecond
 
 func newPTZCmd() *cobra.Command {
 	options := &ptzOptions{}
@@ -73,10 +91,11 @@ func newPTZStatusCmd(options *ptzOptions) *cobra.Command {
 		Short: "Show PTZ capabilities, positions, and ranges",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			device, controller, err := openPTZ(options.device)
+			device, session, controller, err := openPTZ(cmd.Context(), options.device)
 			if err != nil {
 				return err
 			}
+			defer func() { _ = session.Close() }()
 			defer func() { _ = controller.Close() }()
 
 			status, err := controller.Status()
@@ -90,61 +109,122 @@ func newPTZStatusCmd(options *ptzOptions) *cobra.Command {
 
 func newPTZGotoCmd(options *ptzOptions) *cobra.Command {
 	var pan, tilt, zoom float64
+	motion := &ptzMotionOptions{}
 	cmd := &cobra.Command{
 		Use:   "goto",
 		Short: "Move to absolute pan, tilt, or zoom positions",
 		Args:  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return validatePTZMotionFlags(cmd, pan, tilt, zoom)
+			if err := validatePTZMotionFlags(cmd, pan, tilt, zoom); err != nil {
+				return err
+			}
+			return validatePTZTiming(motion)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runPTZMotion(cmd, options, false, pan, tilt, zoom)
+			return runPTZMotion(cmd, options, motion, false, pan, tilt, zoom)
 		},
 	}
 	cmd.Flags().Float64Var(&pan, "pan", 0, "Absolute pan angle in degrees")
 	cmd.Flags().Float64Var(&tilt, "tilt", 0, "Absolute tilt angle in degrees")
 	cmd.Flags().Float64Var(&zoom, "zoom", 0, "Absolute zoom position as a percentage")
+	addPTZTimingFlags(cmd, motion)
 	return cmd
 }
 
 func newPTZMoveCmd(options *ptzOptions) *cobra.Command {
 	var pan, tilt, zoom float64
+	motion := &ptzMotionOptions{}
 	cmd := &cobra.Command{
 		Use:   "move",
 		Short: "Move by relative pan, tilt, or zoom deltas",
 		Args:  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			return validatePTZMotionFlags(cmd, pan, tilt, zoom)
+			if err := validatePTZMotionFlags(cmd, pan, tilt, zoom); err != nil {
+				return err
+			}
+			return validatePTZTiming(motion)
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runPTZMotion(cmd, options, true, pan, tilt, zoom)
+			return runPTZMotion(cmd, options, motion, true, pan, tilt, zoom)
 		},
 	}
 	cmd.Flags().Float64Var(&pan, "pan", 0, "Relative pan delta in degrees")
 	cmd.Flags().Float64Var(&tilt, "tilt", 0, "Relative tilt delta in degrees")
 	cmd.Flags().Float64Var(&zoom, "zoom", 0, "Relative zoom delta in percentage points")
+	addPTZTimingFlags(cmd, motion)
 	return cmd
 }
 
 func newPTZHomeCmd(options *ptzOptions) *cobra.Command {
-	return &cobra.Command{
+	motion := &ptzMotionOptions{}
+	cmd := &cobra.Command{
 		Use:   "home",
 		Short: "Reset pan, tilt, and zoom to their defaults",
 		Args:  cobra.NoArgs,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return validatePTZTiming(motion)
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			device, controller, err := openPTZ(options.device)
+			device, session, controller, err := openPTZ(cmd.Context(), options.device)
 			if err != nil {
 				return err
 			}
-			defer func() { _ = controller.Close() }()
+			defer func() { _ = session.Close() }()
+			defer func() {
+				if controller != nil {
+					_ = controller.Close()
+				}
+			}()
 
+			capabilities := controller.Capabilities()
 			status, err := controller.Home()
 			if err != nil {
 				return fmt.Errorf("home camera %q: %w", device.Name, err)
 			}
-			return writePTZStatus(cmd.OutOrStdout(), options.jsonOutput, makePTZStatusOutput(device, controller.Capabilities(), status))
+			target := ptzTarget{}
+			if status.Pan != nil {
+				target.pan = status.Pan.Range.Clamp(status.Pan.Range.Def)
+				target.checkPan = true
+			}
+			if status.Tilt != nil {
+				target.tilt = status.Tilt.Range.Clamp(status.Tilt.Range.Def)
+				target.checkTilt = true
+			}
+			if status.Zoom != nil {
+				target.zoom = status.Zoom.Range.Clamp(status.Zoom.Range.Def)
+				target.checkZoom = true
+			}
+			if err := controller.Close(); err != nil {
+				return fmt.Errorf("close PTZ control connection for camera %q before verification: %w", device.Name, err)
+			}
+			controller = nil
+			status, err = settlePTZMotion(cmd.Context(), ptzOpenController, device, target, motion)
+			if err != nil {
+				return err
+			}
+			return writePTZStatus(cmd.OutOrStdout(), options.jsonOutput, makePTZStatusOutput(device, capabilities, status))
 		},
 	}
+	addPTZTimingFlags(cmd, motion)
+	return cmd
+}
+
+func addPTZTimingFlags(cmd *cobra.Command, options *ptzMotionOptions) {
+	cmd.Flags().DurationVar(&options.settle, "settle", 2*time.Second, "Time to allow the camera position to settle")
+	cmd.Flags().DurationVar(&options.timeout, "timeout", 5*time.Second, "Overall timeout for verifying the camera position")
+}
+
+func validatePTZTiming(options *ptzMotionOptions) error {
+	if options.settle < 0 {
+		return fmt.Errorf("--settle must not be negative")
+	}
+	if options.timeout <= 0 {
+		return fmt.Errorf("--timeout must be greater than zero")
+	}
+	if options.settle >= options.timeout {
+		return fmt.Errorf("--settle must be less than --timeout")
+	}
+	return nil
 }
 
 func validatePTZMotionFlags(cmd *cobra.Command, pan, tilt, zoom float64) error {
@@ -165,12 +245,17 @@ func validatePTZMotionFlags(cmd *cobra.Command, pan, tilt, zoom float64) error {
 	return nil
 }
 
-func runPTZMotion(cmd *cobra.Command, options *ptzOptions, relative bool, pan, tilt, zoom float64) error {
-	device, controller, err := openPTZ(options.device)
+func runPTZMotion(cmd *cobra.Command, options *ptzOptions, motion *ptzMotionOptions, relative bool, pan, tilt, zoom float64) error {
+	device, session, controller, err := openPTZ(cmd.Context(), options.device)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = controller.Close() }()
+	defer func() { _ = session.Close() }()
+	defer func() {
+		if controller != nil {
+			_ = controller.Close()
+		}
+	}()
 
 	capabilities := controller.Capabilities()
 	status, err := controller.Status()
@@ -189,6 +274,7 @@ func runPTZMotion(cmd *cobra.Command, options *ptzOptions, relative bool, pan, t
 		return fmt.Errorf("camera %q does not support absolute UVC zoom control", device.Name)
 	}
 
+	target := ptzTarget{}
 	if panTiltChanged {
 		panValue := status.Pan.Cur
 		tiltValue := status.Tilt.Cur
@@ -204,9 +290,12 @@ func runPTZMotion(cmd *cobra.Command, options *ptzOptions, relative bool, pan, t
 				tiltValue = addInt32(status.Tilt.Cur, tiltValue)
 			}
 		}
-		if _, _, err := controller.SetPanTilt(panValue, tiltValue); err != nil {
-			return fmt.Errorf("set pan/tilt for camera %q: %w", device.Name, err)
+		appliedPan, appliedTilt, setErr := controller.SetPanTilt(panValue, tiltValue)
+		if setErr != nil {
+			return fmt.Errorf("set pan/tilt for camera %q: %w", device.Name, setErr)
 		}
+		target.pan, target.tilt = appliedPan, appliedTilt
+		target.checkPan, target.checkTilt = true, true
 	}
 
 	if zoomChanged {
@@ -214,36 +303,140 @@ func runPTZMotion(cmd *cobra.Command, options *ptzOptions, relative bool, pan, t
 		if relative {
 			zoomPercent += status.Zoom.Range.PercentOf(status.Zoom.Cur)
 		}
-		if _, err := controller.SetZoom(status.Zoom.Range.FromPercent(zoomPercent)); err != nil {
-			return fmt.Errorf("set zoom for camera %q: %w", device.Name, err)
+		appliedZoom, setErr := controller.SetZoom(status.Zoom.Range.FromPercent(zoomPercent))
+		if setErr != nil {
+			return fmt.Errorf("set zoom for camera %q: %w", device.Name, setErr)
 		}
+		target.zoom, target.checkZoom = appliedZoom, true
 	}
 
-	status, err = controller.Status()
+	if err := controller.Close(); err != nil {
+		return fmt.Errorf("close PTZ control connection for camera %q before verification: %w", device.Name, err)
+	}
+	controller = nil
+	status, err = settlePTZMotion(cmd.Context(), ptzOpenController, device, target, motion)
 	if err != nil {
-		return fmt.Errorf("read applied PTZ status for camera %q: %w", device.Name, err)
+		return err
 	}
 	return writePTZStatus(cmd.OutOrStdout(), options.jsonOutput, makePTZStatusOutput(device, capabilities, status))
 }
 
-func openPTZ(selector string) (localDevice, ptzController, error) {
+func settlePTZMotion(ctx context.Context, openController func(string) (ptzController, error), device localDevice, target ptzTarget, options *ptzMotionOptions) (uvc.Status, error) {
+	controller, err := openController(device.ID)
+	if err != nil {
+		return uvc.Status{}, fmt.Errorf("open fresh PTZ control connection for camera %q: %w", device.Name, err)
+	}
+	defer func() { _ = controller.Close() }()
+
+	deadline := ptzNow().Add(options.timeout)
+	ptzSleep(options.settle)
+
+	var previous ptzTarget
+	havePrevious := false
+	for {
+		if err := ctx.Err(); err != nil {
+			return uvc.Status{}, err
+		}
+
+		observed, err := controller.Status()
+		if err != nil {
+			return uvc.Status{}, fmt.Errorf("read applied PTZ status for camera %q: %w", device.Name, err)
+		}
+		current := ptzReading(observed)
+		if havePrevious && current == previous {
+			if err := verifyPTZTarget(device.Name, observed, target); err != nil {
+				return observed, err
+			}
+			return observed, nil
+		}
+		previous, havePrevious = current, true
+
+		remaining := deadline.Sub(ptzNow())
+		if remaining <= 0 {
+			// Reaching the target is the contract; a readback that keeps
+			// jittering within tolerance (AI framing nudging the gimbal) still
+			// satisfies the request, so only a missed target is an error.
+			if err := verifyPTZTarget(device.Name, observed, target); err != nil {
+				return observed, fmt.Errorf("PTZ position did not settle within %s: %w", options.timeout, err)
+			}
+			return observed, nil
+		}
+		ptzSleep(min(ptzPollInterval, remaining))
+	}
+}
+
+func ptzReading(status uvc.Status) ptzTarget {
+	reading := ptzTarget{}
+	if status.Pan != nil {
+		reading.pan, reading.checkPan = status.Pan.Cur, true
+	}
+	if status.Tilt != nil {
+		reading.tilt, reading.checkTilt = status.Tilt.Cur, true
+	}
+	if status.Zoom != nil {
+		reading.zoom, reading.checkZoom = status.Zoom.Cur, true
+	}
+	return reading
+}
+
+func verifyPTZTarget(camera string, observed uvc.Status, target ptzTarget) error {
+	var differences []string
+	if target.checkPan {
+		differences = appendPTZAxisDifference(differences, "pan", observed.Pan, target.pan, false)
+	}
+	if target.checkTilt {
+		differences = appendPTZAxisDifference(differences, "tilt", observed.Tilt, target.tilt, false)
+	}
+	if target.checkZoom {
+		differences = appendPTZAxisDifference(differences, "zoom", observed.Zoom, target.zoom, true)
+	}
+	if len(differences) == 0 {
+		return nil
+	}
+	return fmt.Errorf("camera %q did not reach its requested PTZ position: %s; the camera may be ignoring UVC because no video stream reached it, or on-camera AI framing/tracking may be overriding UVC positioning; ensure the camera is streaming and disable AI framing/tracking, then retry", camera, strings.Join(differences, "; "))
+}
+
+func appendPTZAxisDifference(differences []string, axis string, observed *uvc.AxisStatus, requested int32, zoom bool) []string {
+	if observed == nil {
+		return append(differences, fmt.Sprintf("%s observed unavailable, requested raw %d", axis, requested))
+	}
+	difference := int64(observed.Cur) - int64(requested)
+	if difference < 0 {
+		difference = -difference
+	}
+	if difference <= max(int64(observed.Range.Res), 0) {
+		return differences
+	}
+	if zoom {
+		return append(differences, fmt.Sprintf("%s observed %.2f%% (%d), requested %.2f%% (%d)", axis, observed.Range.PercentOf(observed.Cur), observed.Cur, observed.Range.PercentOf(requested), requested))
+	}
+	return append(differences, fmt.Sprintf("%s observed %.2f° (%d), requested %.2f° (%d)", axis, uvc.ArcsecToDegrees(observed.Cur), observed.Cur, uvc.ArcsecToDegrees(requested), requested))
+}
+
+func openPTZ(ctx context.Context, selector string) (localDevice, io.Closer, ptzController, error) {
 	device, err := ptzResolveDevice(selector)
 	if err != nil {
 		name := selector
 		if name == "" {
 			name = "default camera"
 		}
-		return localDevice{}, nil, fmt.Errorf("resolve PTZ camera %q: %w", name, err)
+		return localDevice{}, nil, nil, fmt.Errorf("resolve PTZ camera %q: %w", name, err)
+	}
+	session, err := ptzOpenSession(ctx, device.ID)
+	if err != nil {
+		return localDevice{}, nil, nil, fmt.Errorf("open video stream for PTZ camera %q: %w", device.Name, err)
 	}
 	controller, err := ptzOpenController(device.ID)
 	if err != nil {
-		return localDevice{}, nil, fmt.Errorf("camera %q does not support USB UVC PTZ control: %w", device.Name, err)
+		_ = session.Close()
+		return localDevice{}, nil, nil, fmt.Errorf("camera %q does not support USB UVC PTZ control: %w", device.Name, err)
 	}
 	if !controller.Capabilities().Any() {
 		_ = controller.Close()
-		return localDevice{}, nil, fmt.Errorf("camera %q does not advertise any UVC PTZ controls", device.Name)
+		_ = session.Close()
+		return localDevice{}, nil, nil, fmt.Errorf("camera %q does not advertise any UVC PTZ controls", device.Name)
 	}
-	return device, controller, nil
+	return device, session, controller, nil
 }
 
 func resolveNativePTZDevice(selector string) (localDevice, error) {

--- a/internal/cli/ptz_test.go
+++ b/internal/cli/ptz_test.go
@@ -2,9 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steipete/camsnap/internal/uvc"
 )
@@ -17,36 +21,84 @@ type fakePTZController struct {
 	setZoom      int32
 	panTiltSets  int
 	zoomSets     int
+	statusCalls  int
+	statusValues []uvc.Status
+	ignoreWrites bool
 	closed       bool
+	events       *[]string
 }
 
-func (f *fakePTZController) Capabilities() uvc.Capabilities { return f.capabilities }
-func (f *fakePTZController) Status() (uvc.Status, error)    { return f.status, nil }
+type fakePTZSession struct {
+	closed bool
+	events *[]string
+	sleeps []time.Duration
+}
+
+func (s *fakePTZSession) Close() error {
+	s.closed = true
+	if s.events != nil {
+		*s.events = append(*s.events, "session-close")
+	}
+	return nil
+}
+
+func (f *fakePTZController) record(event string) {
+	if f.events != nil {
+		*f.events = append(*f.events, event)
+	}
+}
+
+func (f *fakePTZController) Capabilities() uvc.Capabilities {
+	f.record("capabilities")
+	return f.capabilities
+}
+
+func (f *fakePTZController) Status() (uvc.Status, error) {
+	f.record("status")
+	f.statusCalls++
+	if len(f.statusValues) > 0 {
+		status := f.statusValues[0]
+		f.statusValues = f.statusValues[1:]
+		return clonePTZStatus(status), nil
+	}
+	return clonePTZStatus(f.status), nil
+}
+
 func (f *fakePTZController) SetPanTilt(pan, tilt int32) (int32, int32, error) {
+	f.record("set-pan-tilt")
 	f.setPan = f.status.Pan.Range.Clamp(pan)
 	f.setTilt = f.status.Tilt.Range.Clamp(tilt)
-	f.status.Pan.Cur = f.setPan
-	f.status.Tilt.Cur = f.setTilt
+	if !f.ignoreWrites {
+		f.status.Pan.Cur = f.setPan
+		f.status.Tilt.Cur = f.setTilt
+	}
 	f.panTiltSets++
 	return f.setPan, f.setTilt, nil
 }
 func (f *fakePTZController) SetZoom(zoom int32) (int32, error) {
+	f.record("set-zoom")
 	f.setZoom = f.status.Zoom.Range.Clamp(zoom)
-	f.status.Zoom.Cur = f.setZoom
+	if !f.ignoreWrites {
+		f.status.Zoom.Cur = f.setZoom
+	}
 	f.zoomSets++
 	return f.setZoom, nil
 }
 func (f *fakePTZController) Home() (uvc.Status, error) {
-	if f.status.Pan != nil {
-		f.status.Pan.Cur = f.status.Pan.Range.Def
-		f.status.Tilt.Cur = f.status.Tilt.Range.Def
+	f.record("home")
+	if !f.ignoreWrites {
+		if f.status.Pan != nil {
+			f.status.Pan.Cur = f.status.Pan.Range.Def
+			f.status.Tilt.Cur = f.status.Tilt.Range.Def
+		}
+		if f.status.Zoom != nil {
+			f.status.Zoom.Cur = f.status.Zoom.Range.Def
+		}
 	}
-	if f.status.Zoom != nil {
-		f.status.Zoom.Cur = f.status.Zoom.Range.Def
-	}
-	return f.status, nil
+	return clonePTZStatus(f.status), nil
 }
 func (f *fakePTZController) Close() error {
+	f.record("controller-close")
 	f.closed = true
 	return nil
 }
@@ -142,6 +194,287 @@ func TestPTZMoveZoomUsesPercentagePointDelta(t *testing.T) {
 	}
 }
 
+func TestPTZMotionReportsObservedSettledPosition(t *testing.T) {
+	controller := newFakePTZController()
+	initial := clonePTZStatus(controller.status)
+	observed := clonePTZStatus(controller.status)
+	observed.Pan.Cur = 45900
+	controller.statusValues = []uvc.Status{initial, observed, observed}
+	restore := stubPTZBackend(t, controller)
+	defer restore()
+
+	root := NewRootCommand("test")
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"ptz", "goto", "--pan", "12.5", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	var status ptzStatusOutput
+	if err := json.Unmarshal(output.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.Pan == nil || status.Pan.Raw != 45900 {
+		t.Fatalf("observed pan = %#v, want raw 45900", status.Pan)
+	}
+}
+
+func TestPTZMotionRejectsSettledMismatch(t *testing.T) {
+	controller := newFakePTZController()
+	controller.ignoreWrites = true
+	restore := stubPTZBackend(t, controller)
+	defer restore()
+
+	root := NewRootCommand("test")
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"ptz", "goto", "--pan", "12.5"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("Execute succeeded despite the camera ignoring its requested position")
+	}
+	for _, want := range []string{
+		"pan observed 1.00° (3600), requested 12.50° (45000)",
+		"no video stream reached it",
+		"AI framing/tracking",
+		"then retry",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q: %v", want, err)
+		}
+	}
+	if output.Len() != 0 {
+		t.Fatalf("mismatched motion printed a success table: %s", output.String())
+	}
+	if !controller.closed {
+		t.Fatal("controller was not closed after the verification failure")
+	}
+}
+
+func TestPTZMotionRejectsSetpointEchoFromWriteConnection(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		requested string
+	}{
+		{name: "goto", args: []string{"ptz", "goto", "--pan", "140"}, requested: "requested 140.00° (504000)"},
+		{name: "move", args: []string{"ptz", "move", "--pan", "240"}, requested: "requested 140.00° (504000)"},
+		{name: "home", args: []string{"ptz", "home"}, requested: "requested 0.00° (0)"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var events []string
+			writer := newFakePTZController()
+			writer.status.Pan.Range.Min = -648000
+			writer.status.Pan.Range.Max = 648000
+			writer.status.Pan.Cur = -360000
+			writer.events = &events
+
+			verifier := newFakePTZController()
+			verifier.status = clonePTZStatus(writer.status)
+			verifier.events = &events
+			session, restore := stubPTZBackendWithSession(t, writer, verifier)
+			defer restore()
+			session.events = &events
+
+			root := NewRootCommand("test")
+			root.SetOut(&bytes.Buffer{})
+			root.SetArgs(test.args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("Execute accepted the write connection's echoed setpoint despite an unmoved camera")
+			}
+			for _, want := range []string{"did not reach its requested PTZ position", "pan observed -100.00° (-360000)", test.requested} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error missing %q: %v", want, err)
+				}
+			}
+			if writer.status.Pan.Cur == verifier.status.Pan.Cur {
+				t.Fatal("fake did not model a write-only setpoint echo")
+			}
+			if verifier.statusCalls < 2 {
+				t.Fatalf("fresh connection status calls = %d, want consecutive verification samples", verifier.statusCalls)
+			}
+			if !writer.closed || !verifier.closed || !session.closed {
+				t.Fatalf("resource closure: writer=%t verifier=%t session=%t", writer.closed, verifier.closed, session.closed)
+			}
+			if len(events) < 6 || events[0] != "session-open" || events[len(events)-1] != "session-close" {
+				t.Fatalf("capture session did not outlive both controller connections: %v", events)
+			}
+			opens, writerClosed := 0, false
+			for _, event := range events {
+				switch event {
+				case "controller-close":
+					writerClosed = true
+				case "controller-open":
+					opens++
+					if opens == 2 && !writerClosed {
+						t.Fatalf("verification connection opened before the writer closed: %v", events)
+					}
+				}
+			}
+			if opens != 2 {
+				t.Fatalf("controller opens = %d, want write and fresh verification connections: %v", opens, events)
+			}
+		})
+	}
+}
+
+func TestPTZMotionAcceptsCommittedPositionFromFreshConnection(t *testing.T) {
+	writer := newFakePTZController()
+	writer.status.Pan.Range.Min = -648000
+	writer.status.Pan.Cur = 0
+	verifier := newFakePTZController()
+	verifier.status = clonePTZStatus(writer.status)
+	verifier.status.Pan.Cur = -360000
+	session, restore := stubPTZBackendWithSession(t, writer, verifier)
+	defer restore()
+
+	var output bytes.Buffer
+	root := NewRootCommand("test")
+	root.SetOut(&output)
+	root.SetArgs([]string{"ptz", "goto", "--pan", "-100"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("committed movement failed fresh-connection verification: %v", err)
+	}
+	if writer.statusCalls != 1 || verifier.statusCalls < 2 {
+		t.Fatalf("status calls: writer=%d verifier=%d", writer.statusCalls, verifier.statusCalls)
+	}
+	if !strings.Contains(output.String(), "-360000") {
+		t.Fatalf("output omitted the committed position: %s", output.String())
+	}
+	if !writer.closed || !verifier.closed || !session.closed {
+		t.Fatalf("resource closure: writer=%t verifier=%t session=%t", writer.closed, verifier.closed, session.closed)
+	}
+}
+
+func TestPTZMotionWaitsForConsecutiveStableSamples(t *testing.T) {
+	controller := newFakePTZController()
+	initial := clonePTZStatus(controller.status)
+	moving := clonePTZStatus(controller.status)
+	moving.Pan.Cur = 18000
+	settled := clonePTZStatus(controller.status)
+	settled.Pan.Cur = 45000
+	controller.statusValues = []uvc.Status{initial, moving, settled, settled}
+	session, restore := stubPTZBackendWithSession(t, controller)
+	defer restore()
+
+	root := NewRootCommand("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"ptz", "goto", "--pan", "12.5", "--settle", "2ms", "--timeout", "500ms"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if controller.statusCalls != 4 {
+		t.Fatalf("status calls = %d, want initial read plus three verification samples", controller.statusCalls)
+	}
+	if len(session.sleeps) != 3 || session.sleeps[0] != 2*time.Millisecond {
+		t.Fatalf("verification waits = %v, want settle then two polling intervals", session.sleeps)
+	}
+}
+
+func TestPTZMotionTimesOutWhilePositionIsStillChanging(t *testing.T) {
+	controller := newFakePTZController()
+	initial := clonePTZStatus(controller.status)
+	first := clonePTZStatus(controller.status)
+	first.Pan.Cur = 18000
+	second := clonePTZStatus(controller.status)
+	second.Pan.Cur = 27000
+	controller.statusValues = []uvc.Status{initial, first, second}
+	session, restore := stubPTZBackendWithSession(t, controller)
+	defer restore()
+
+	root := NewRootCommand("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"ptz", "goto", "--pan", "12.5", "--settle", "0s", "--timeout", "2ms"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "did not settle within 2ms") {
+		t.Fatalf("timeout error = %v", err)
+	}
+	if !strings.Contains(err.Error(), "pan observed 7.50° (27000), requested 12.50° (45000)") {
+		t.Fatalf("timeout omitted the last observed position: %v", err)
+	}
+	if !session.closed || !controller.closed {
+		t.Fatal("capture session or controller remained open after the verification timeout")
+	}
+}
+
+func TestPTZOperationsKeepSessionOpenAroundUVCWork(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "status", args: []string{"ptz", "status"}},
+		{name: "goto", args: []string{"ptz", "goto", "--pan", "12.5"}},
+		{name: "move", args: []string{"ptz", "move", "--zoom", "25"}},
+		{name: "home", args: []string{"ptz", "home"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var events []string
+			controller := newFakePTZController()
+			controller.events = &events
+			session, restore := stubPTZBackendWithSession(t, controller)
+			defer restore()
+			session.events = &events
+
+			root := NewRootCommand("test")
+			root.SetOut(&bytes.Buffer{})
+			root.SetArgs(test.args)
+			if err := root.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			if len(events) < 4 || events[0] != "session-open" || events[1] != "controller-open" {
+				t.Fatalf("session did not open before UVC work: %v", events)
+			}
+			if events[len(events)-2] != "controller-close" || events[len(events)-1] != "session-close" {
+				t.Fatalf("session did not close after UVC work: %v", events)
+			}
+			if !session.closed {
+				t.Fatal("capture session was not closed")
+			}
+		})
+	}
+}
+
+func TestPTZMotionRejectsInvalidTiming(t *testing.T) {
+	tests := []struct {
+		args []string
+		want string
+	}{
+		{args: []string{"ptz", "goto", "--pan", "1", "--settle", "-1ms"}, want: "--settle must not be negative"},
+		{args: []string{"ptz", "move", "--pan", "1", "--timeout", "0s"}, want: "--timeout must be greater than zero"},
+		{args: []string{"ptz", "home", "--settle", "5s", "--timeout", "5s"}, want: "--settle must be less than --timeout"},
+	}
+	for _, test := range tests {
+		root := NewRootCommand("test")
+		root.SetArgs(test.args)
+		if err := root.Execute(); err == nil || !strings.Contains(err.Error(), test.want) {
+			t.Errorf("Execute(%v) error = %v, want %q", test.args, err, test.want)
+		}
+	}
+}
+
+func TestPTZSessionFailurePreservesCameraPermissionRemediation(t *testing.T) {
+	controller := newFakePTZController()
+	restore := stubPTZBackend(t, controller)
+	defer restore()
+	ptzOpenSession = func(context.Context, string) (io.Closer, error) {
+		return nil, errors.New("camera access is denied\n" + cameraPermissionRemediation)
+	}
+
+	root := NewRootCommand("test")
+	root.SetArgs([]string{"ptz", "status"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), cameraPermissionRemediation) {
+		t.Fatalf("permission error = %v", err)
+	}
+	if controller.statusCalls != 0 {
+		t.Fatal("UVC status was queried after the capture session failed")
+	}
+}
+
 func TestWritePTZStatusTable(t *testing.T) {
 	controller := newFakePTZController()
 	status := makePTZStatusOutput(
@@ -168,21 +501,53 @@ func TestWritePTZStatusTable(t *testing.T) {
 
 func TestOpenPTZNamesUnsupportedCamera(t *testing.T) {
 	oldResolve := ptzResolveDevice
+	oldSession := ptzOpenSession
 	oldOpen := ptzOpenController
+	session := &fakePTZSession{}
 	ptzResolveDevice = func(string) (localDevice, error) {
 		return localDevice{ID: "continuity-id", Name: "Continuity Camera"}, nil
+	}
+	ptzOpenSession = func(context.Context, string) (io.Closer, error) {
+		return session, nil
 	}
 	ptzOpenController = func(string) (ptzController, error) {
 		return &fakePTZController{}, nil
 	}
 	t.Cleanup(func() {
 		ptzResolveDevice = oldResolve
+		ptzOpenSession = oldSession
 		ptzOpenController = oldOpen
 	})
 
-	_, _, err := openPTZ("")
+	_, _, _, err := openPTZ(context.Background(), "")
 	if err == nil || !strings.Contains(err.Error(), `camera "Continuity Camera" does not advertise any UVC PTZ controls`) {
 		t.Fatalf("openPTZ error = %v", err)
+	}
+	if !session.closed {
+		t.Fatal("capture session was not closed for an unsupported camera")
+	}
+}
+
+func TestPTZMotionAcceptsOnTargetJitterAtTimeout(t *testing.T) {
+	controller := newFakePTZController()
+	initial := clonePTZStatus(controller.status)
+	onTarget := clonePTZStatus(controller.status)
+	onTarget.Pan.Cur = 45000
+	jittered := clonePTZStatus(controller.status)
+	jittered.Pan.Cur = 44100
+	controller.statusValues = []uvc.Status{initial, onTarget, jittered}
+	_, restore := stubPTZBackendWithSession(t, controller)
+	defer restore()
+
+	output := &bytes.Buffer{}
+	root := NewRootCommand("test")
+	root.SetOut(output)
+	root.SetArgs([]string{"ptz", "goto", "--pan", "12.5", "--settle", "0s", "--timeout", "2ms"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("readback jitter within the control resolution must not fail: %v", err)
+	}
+	if !strings.Contains(output.String(), "44100") {
+		t.Fatalf("output must report the observed position, got: %s", output.String())
 	}
 }
 
@@ -205,24 +570,77 @@ func newFakePTZController() *fakePTZController {
 	}
 }
 
+func clonePTZStatus(status uvc.Status) uvc.Status {
+	result := uvc.Status{}
+	if status.Pan != nil {
+		pan := *status.Pan
+		result.Pan = &pan
+	}
+	if status.Tilt != nil {
+		tilt := *status.Tilt
+		result.Tilt = &tilt
+	}
+	if status.Zoom != nil {
+		zoom := *status.Zoom
+		result.Zoom = &zoom
+	}
+	return result
+}
+
 func stubPTZBackend(t *testing.T, controller ptzController) func() {
 	t.Helper()
+	_, restore := stubPTZBackendWithSession(t, controller)
+	return restore
+}
+
+func stubPTZBackendWithSession(t *testing.T, controller ptzController, verification ...ptzController) (*fakePTZSession, func()) {
+	t.Helper()
 	oldResolve := ptzResolveDevice
+	oldSession := ptzOpenSession
 	oldOpen := ptzOpenController
+	oldNow := ptzNow
+	oldSleep := ptzSleep
+	session := &fakePTZSession{}
+	now := time.Unix(0, 0)
+	opens := 0
 	ptzResolveDevice = func(selector string) (localDevice, error) {
 		if selector != "" && selector != "Link" {
 			t.Fatalf("device selector = %q", selector)
 		}
 		return localDevice{ID: "camera-id", Index: "0", Name: "Insta360 Link", IsDefault: true}, nil
 	}
+	ptzOpenSession = func(_ context.Context, uniqueID string) (io.Closer, error) {
+		if uniqueID != "camera-id" {
+			t.Fatalf("session unique ID = %q", uniqueID)
+		}
+		if session.events != nil {
+			*session.events = append(*session.events, "session-open")
+		}
+		return session, nil
+	}
 	ptzOpenController = func(uniqueID string) (ptzController, error) {
 		if uniqueID != "camera-id" {
 			t.Fatalf("unique ID = %q", uniqueID)
 		}
+		if session.events != nil {
+			*session.events = append(*session.events, "controller-open")
+		}
+		opens++
+		if opens > 1 && len(verification) > 0 {
+			return verification[0], nil
+		}
 		return controller, nil
 	}
-	return func() {
+	ptzNow = func() time.Time { return now }
+	ptzSleep = func(duration time.Duration) {
+		session.sleeps = append(session.sleeps, duration)
+		now = now.Add(duration)
+	}
+	return session, func() {
 		ptzResolveDevice = oldResolve
+		ptzOpenSession = oldSession
 		ptzOpenController = oldOpen
+		ptzNow = oldNow
+		ptzSleep = oldSleep
 	}
 }

--- a/internal/cli/ptzbackend_darwin_cgo.go
+++ b/internal/cli/ptzbackend_darwin_cgo.go
@@ -2,7 +2,25 @@
 
 package cli
 
-import "github.com/steipete/camsnap/internal/uvc"
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/steipete/camsnap/internal/avf"
+	"github.com/steipete/camsnap/internal/uvc"
+)
+
+func openNativePTZSession(ctx context.Context, uniqueID string) (io.Closer, error) {
+	if err := preflightNativeCamera(ctx, true, nil); err != nil {
+		return nil, err
+	}
+	session, err := avf.OpenSession(uniqueID)
+	if err != nil && isNativePermissionError(err) {
+		return nil, fmt.Errorf("%w\n%s", err, cameraPermissionRemediation)
+	}
+	return session, err
+}
 
 func openNativePTZController(uniqueID string) (ptzController, error) {
 	return uvc.Open(uniqueID)

--- a/internal/cli/ptzbackend_stub.go
+++ b/internal/cli/ptzbackend_stub.go
@@ -2,7 +2,16 @@
 
 package cli
 
-import "github.com/steipete/camsnap/internal/uvc"
+import (
+	"context"
+	"io"
+
+	"github.com/steipete/camsnap/internal/uvc"
+)
+
+func openNativePTZSession(context.Context, string) (io.Closer, error) {
+	return nil, uvc.ErrUnsupported
+}
 
 func openNativePTZController(string) (ptzController, error) {
 	return nil, uvc.ErrUnsupported

--- a/internal/uvc/bridge.m
+++ b/internal/uvc/bridge.m
@@ -1,3 +1,5 @@
+//go:build darwin && cgo
+
 #import "bridge.h"
 
 #import <CoreFoundation/CoreFoundation.h>

--- a/internal/uvc/uvc.go
+++ b/internal/uvc/uvc.go
@@ -10,24 +10,6 @@ import (
 	"strings"
 )
 
-// UVC camera terminal control selectors (UVC 1.5, table A-12).
-const (
-	selZoomAbsolute    = 0x0B
-	selZoomRelative    = 0x0C
-	selPanTiltAbsolute = 0x0D
-	selPanTiltRelative = 0x0E
-)
-
-// UVC class-specific request codes (UVC 1.5, table A-8).
-const (
-	reqSetCur = 0x01
-	reqGetCur = 0x81
-	reqGetMin = 0x82
-	reqGetMax = 0x83
-	reqGetRes = 0x84
-	reqGetDef = 0x87
-)
-
 // Camera terminal bmControls bit positions (UVC 1.5, table 3-6).
 const (
 	ctrlBitZoomAbsolute    = 9

--- a/internal/uvc/uvc_darwin_cgo.go
+++ b/internal/uvc/uvc_darwin_cgo.go
@@ -17,6 +17,24 @@ import (
 	"unsafe"
 )
 
+// UVC camera terminal control selectors (UVC 1.5, table A-12).
+const (
+	selZoomAbsolute    = 0x0B
+	selZoomRelative    = 0x0C
+	selPanTiltAbsolute = 0x0D
+	selPanTiltRelative = 0x0E
+)
+
+// UVC class-specific request codes (UVC 1.5, table A-8).
+const (
+	reqSetCur = 0x01
+	reqGetCur = 0x81
+	reqGetMin = 0x82
+	reqGetMax = 0x83
+	reqGetRes = 0x84
+	reqGetDef = 0x87
+)
+
 // Controller controls the camera terminal of one USB UVC device.
 type Controller struct {
 	mu           sync.Mutex


### PR DESCRIPTION
## What Problem This Solves

`camsnap ptz goto`, `move`, and `home` printed a success table and exited 0 for moves that never happened.

Reproduced on an Insta360 Link 2 Pro: with the camera at pan 0, `camsnap ptz goto --device 0 --pan 60 --tilt -18` printed `PAN true true 60.00° 216000` and exited 0. Four seconds later the device was still at pan 0. It never moved. This reproduced with macOS camera permission both granted and denied, so TCC was not the gate.

Two device behaviors combined to defeat the old check:

1. **Gimbal webcams only service UVC camera-terminal controls while a video stream is active.** With no stream, `GET_CUR` returns phantom values (tilt read `-306000` / -85° while the camera physically sat near -18°) and `SET_CUR` is accepted and then silently discarded.
2. **The device echoes its pending setpoint back on the same USB control connection that wrote it.** A connection that never wrote reports the true committed position.

`runPTZMotion` performed its IOKit transfers with no capture session open, and held a single `uvc.Controller` across the write and the readback. So it confirmed its own write, and the verification could never detect a refused move.

Evidence for (2), after `goto --pan 140`:

| reader | pan |
| --- | --- |
| `goto`'s own inline read | `504000` (exit 0) |
| fresh `uvcc` process | `-360000` |
| fresh `camsnap ptz status` | `-360000` |

## Why This Change Was Made

Silent success is the worst failure mode for this command: callers scripting a pose have no way to know the camera ignored them. Verification has to read through a connection that did not perform the write, and the device has to be streaming for any of it to be meaningful.

## User Impact

- Every `ptz` subcommand now holds an AVFoundation capture session open for the operation, so positions are real rather than phantom. **This means `ptz` now requires macOS Camera permission**, reusing the existing actionable permission error.
- Motion commands settle, sample until the reading is stable, print the **observed** position rather than the requested one, and exit non-zero when the gimbal did not land within the camera's reported control resolution.
- New `--settle` (default `2s`) and `--timeout` (default `5s`) flags. Additive; existing flags, defaults, table columns, and JSON field names are unchanged.
- **Behavior change worth knowing:** on a camera whose on-camera AI framing/tracking is active, moves that the camera overrides now correctly report failure where they previously reported a comforting lie. The error text names streaming and AI tracking as the causes.

## Evidence

`make all`, `go build ./...`, `CGO_ENABLED=0 go test ./...`, and `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...` all pass.

Live hardware run on an Insta360 Link 2 Pro with the built, signed binary. Each pose was confirmed three ways: the command's own reported position, an independent `uvcc` process reading `GET_CUR`, and a captured frame checked against a previously mapped 290° sweep of the room.

| command | exit | reported | independent read | frame shows |
| --- | --- | --- | --- | --- |
| `goto --pan -60 --tilt -18` | 0 | `-216000` | matches | the kitchen, matching -56° on the reference sweep |
| `goto --pan 20 --tilt -18` | 0 | `72000` | `72000` | the desk, matching ~+18° |
| `goto --pan 140 --tilt -18` | 0 | `504000` | `504000` | the far wall, matching +145° |
| `goto --pan -4 --tilt -18` (camera refused) | **1** | observed vs requested | unmoved | unmoved |

The last row is the point of the change: a refused move now exits non-zero and names the observed position, instead of printing a fabricated success table.

Regression tests model the connection-local setpoint echo, assert verification consults a fresh connection, assert the write controller is closed before the verification controller opens and that the capture session outlives both, and cover the on-target-at-timeout case. Each fails against the pre-fix code.

Frames are photographs of a private home, so they are not attached here; they can be supplied privately on request.


## CI repairs included

Two latent build breaks surfaced on the Linux lane and are fixed here rather than left red. `main` has had no CI run since before the PTZ feature landed, so neither was previously visible.

- `internal/uvc/bridge.m` and `internal/avf/bridge.m` carried no build constraint, so Go rejected the Objective-C sources on Linux (`Objective-C source files not allowed when not using cgo or SWIG`). Both now declare `//go:build darwin && cgo`.
- With the bridge correctly constrained, Linux lint compiled the package's portable Go and flagged ten UVC selector/request constants as unused, since only `uvc_darwin_cgo.go` references them. Both const blocks moved next to their implementation.

Verified with `golangci-lint run ./...` on darwin and under `GOOS=linux GOARCH=amd64`, both clean, plus `make all`, `make build`, and the cross-platform build checks.
