### PR TITLE
feat(sweep): capture a verified pan sweep in one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.4.2 - Unreleased
+- Add native single-session PTZ pan sweeps with verified frames, requested-versus-observed JSON manifests, and optional fail-fast handling.
 
 ## 0.4.1 - 2026-08-24
 - Fix `ptz goto`, `move`, and `home` reporting success for movements the camera never performed.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ camsnap stores configuration in `~/.config/camsnap/config.yaml`, or `$XDG_CONFIG
 | `discover` | Find ONVIF devices on the local network. |
 | `devices` | List local video inputs. |
 | `ptz` | Control pan, tilt, and zoom on supported USB webcams. |
+| `sweep` | Capture verified frames across a local PTZ camera's pan arc. |
 | `doctor` | Check `ffmpeg`, connectivity, and optional capture probes. |
 
 Run `camsnap <command> --help` for the complete flags and defaults.
@@ -120,11 +121,14 @@ camsnap ptz goto --device 0 --pan 12.5 --tilt -5 --zoom 50
 camsnap ptz move --device 0 --pan -10 --zoom 5
 camsnap ptz home --device 0
 camsnap ptz goto --device 0 --pan 45 --settle 3s --timeout 6s
+camsnap sweep --device 0 --from -45 --to 45 --steps 7 --out-dir panorama
 ```
 
 PTZ commands keep the selected camera streaming while reading or changing its position, so they require macOS Camera permission. Motion commands verify the observed position after `--settle` (default `2s`) and fail if it does not stabilize before `--timeout` (default `5s`).
 
-See [Local webcams](docs/local-webcams.md) for stable macOS device selectors, Camera permission behavior, UVC PTZ control, Linux device paths, and backend selection.
+`sweep` keeps one native capture session open across the entire arc and writes numbered JPEG frames plus `manifest.json`. The manifest records requested and observed pan/tilt for each frame; failed positions are retained and reported with a non-zero exit status. Add `--fail-fast` to stop after the first failed position, or `--json` to print the manifest.
+
+See [Local webcams](docs/local-webcams.md) for stable macOS device selectors, Camera permission behavior, UVC PTZ control and sweeps, Linux device paths, and backend selection.
 
 ## Platform support
 

--- a/docs/local-webcams.md
+++ b/docs/local-webcams.md
@@ -74,6 +74,40 @@ The status table shows raw UVC ranges: pan and tilt use arcseconds, while zoom u
 
 PTZ requires a cgo-enabled macOS build and a directly attached USB UVC camera with absolute controls. Built-in cameras, Studio Display cameras, Continuity Camera, and devices that do not expose UVC PTZ controls return a named unsupported-camera error.
 
+## Capture a pan sweep
+
+`camsnap sweep` moves an absolute-pan/tilt USB camera through evenly spaced positions and captures a JPEG at each stop. It keeps one native AVFoundation session streaming throughout the entire sweep, including movement, fresh-connection verification, and frame capture:
+
+```sh
+camsnap sweep --device 0 --from -45 --to 45 --steps 7 --out-dir panorama
+camsnap sweep desk --from -60 --to 60 --steps 9 --tilt -5 \
+  --settle 3s --timeout 6s --out-dir desk-panorama --json
+camsnap sweep --device 0 --from 30 --to -30 --steps 5 \
+  --out-dir reverse-panorama --fail-fast
+```
+
+The start and end positions are clamped and snapped to the camera's reported pan range and resolution. `--tilt` sets a fixed, clamped tilt for every frame; when omitted, the sweep preserves the current tilt. `--steps` must be at least two and includes both endpoints. `--warmup` applies once before the first frame; `--video-size` and `--framerate` follow the existing native-snapshot behavior. Sweeps require the native backend because ffmpeg cannot capture from the same already-open AVFoundation stream.
+
+Each output directory contains stable names such as `step-000-pan--45.000.jpg` and `manifest.json`. The manifest includes the selected device, effective start/end/tilt angles, requested step count, and one entry per captured frame:
+
+```json
+{
+  "index": 0,
+  "requested": {
+    "pan": { "degrees": -45, "raw": -162000 },
+    "tilt": { "degrees": -5, "raw": -18000 }
+  },
+  "observed": {
+    "pan": { "degrees": -45, "raw": -162000 },
+    "tilt": { "degrees": -5, "raw": -18000 }
+  },
+  "frame_path": "panorama/step-000-pan--45.000.jpg",
+  "verified": true
+}
+```
+
+A position that misses the camera's reported control resolution is still photographed and recorded with `"verified": false` and a `verification_error`. By default the remaining steps continue, then the command exits non-zero and names the failed step indices. `--fail-fast` stops after capturing the first failed step and still writes the partial manifest. `--json` prints the exact same manifest bytes that are saved to disk.
+
 ## Building the native backend
 
 `make build` embeds the Camera usage-description plist and applies an ad-hoc signature. Set `CAMSNAP_CODESIGN_IDENTITY` to use a local Developer ID identity instead.

--- a/internal/avf/avf.go
+++ b/internal/avf/avf.go
@@ -31,7 +31,7 @@ type Device struct {
 	IsDefault bool
 }
 
-// Session keeps a camera's video stream active without saving any frames.
+// Session keeps a camera's video stream active and can capture individual frames.
 type Session struct {
 	mu     sync.Mutex
 	handle unsafe.Pointer
@@ -139,6 +139,34 @@ func (s *Session) Close() error {
 	var cErr *C.char
 	if C.avf_close_session(handle, &cErr) == 0 {
 		return bridgeError(cErr, "close capture session")
+	}
+	return nil
+}
+
+// CaptureFrame writes one JPEG from the already-running capture session.
+// A zero warmup captures the next available frame without restarting the stream.
+func (s *Session) CaptureFrame(warmup time.Duration, outPath string) error {
+	if outPath == "" {
+		return errors.New("avf: output path is required")
+	}
+	if warmup < 0 {
+		return errors.New("avf: warmup must not be negative")
+	}
+	if s == nil {
+		return errors.New("avf: capture session is closed")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.handle == nil {
+		return errors.New("avf: capture session is closed")
+	}
+
+	cOutPath := C.CString(outPath)
+	defer C.free(unsafe.Pointer(cOutPath))
+
+	var cErr *C.char
+	if C.avf_capture_session_frame(s.handle, C.double(warmup.Seconds()), cOutPath, &cErr) == 0 {
+		return bridgeError(cErr, "capture session frame")
 	}
 	return nil
 }

--- a/internal/avf/avf_test.go
+++ b/internal/avf/avf_test.go
@@ -50,3 +50,16 @@ func TestCaptureFrameRequiresOutputPath(t *testing.T) {
 		t.Fatal("CaptureFrame returned nil error for an empty output path")
 	}
 }
+
+func TestSessionCaptureFrameRejectsInvalidInput(t *testing.T) {
+	var session *Session
+	if err := session.CaptureFrame(0, ""); err == nil {
+		t.Fatal("CaptureFrame returned nil error for an empty output path")
+	}
+	if err := session.CaptureFrame(-1, "frame.jpg"); err == nil {
+		t.Fatal("CaptureFrame returned nil error for a negative warmup")
+	}
+	if err := session.CaptureFrame(0, "frame.jpg"); err == nil {
+		t.Fatal("CaptureFrame returned nil error for a closed session")
+	}
+}

--- a/internal/avf/bridge.h
+++ b/internal/avf/bridge.h
@@ -17,6 +17,7 @@ int avf_request_access(unsigned long long token, char **error_out);
 
 void *avf_open_session(const char *device_id, char **error_out);
 int avf_close_session(void *session, char **error_out);
+int avf_capture_session_frame(void *session, double warmup_seconds, const char *out_path, char **error_out);
 int avf_capture_frame(const char *device_id, double warmup_seconds, const char *out_path, char **error_out);
 
 extern void goAVFAccessResult(unsigned long long token, int granted);

--- a/internal/avf/bridge.m
+++ b/internal/avf/bridge.m
@@ -241,6 +241,7 @@ int avf_request_access(unsigned long long token, char **error_out) {
 @property(nonatomic, readonly) dispatch_semaphore_t semaphore;
 
 - (instancetype)initWithSession:(AVCaptureSession *)session output:(AVCaptureVideoDataOutput *)output;
+- (BOOL)captureFrameAtPath:(NSString *)output_path warmup:(NSTimeInterval)warmup error:(char **)error_out;
 - (void)stop;
 
 @end
@@ -274,6 +275,31 @@ int avf_request_access(unsigned long long token, char **error_out) {
         _received_frame = YES;
         dispatch_semaphore_signal(_semaphore);
     }
+}
+
+- (BOOL)captureFrameAtPath:(NSString *)output_path warmup:(NSTimeInterval)warmup error:(char **)error_out {
+    AVFFrameReceiver *receiver = [[AVFFrameReceiver alloc]
+        initWithOutputPath:output_path
+                    warmup:warmup];
+    [_output setSampleBufferDelegate:receiver queue:_queue];
+
+    NSTimeInterval timeout_seconds = warmup + 10.0;
+    long wait_result = dispatch_semaphore_wait(
+        receiver.semaphore,
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout_seconds * NSEC_PER_SEC))
+    );
+    [_output setSampleBufferDelegate:self queue:_queue];
+    dispatch_sync(_queue, ^{});
+
+    if (wait_result != 0) {
+        AVFSetError(error_out, @"timed out waiting for a video frame");
+        return NO;
+    }
+    if (receiver.failure != nil) {
+        AVFSetError(error_out, receiver.failure);
+        return NO;
+    }
+    return YES;
 }
 
 - (void)stop {
@@ -397,6 +423,24 @@ int avf_close_session(void *session, char **error_out) {
             return 1;
         } @catch (NSException *exception) {
             AVFSetError(error_out, [NSString stringWithFormat:@"close capture session: %@", exception.reason]);
+            return 0;
+        }
+    }
+}
+
+int avf_capture_session_frame(void *session, double warmup_seconds, const char *out_path, char **error_out) {
+    @autoreleasepool {
+        if (session == NULL || out_path == NULL || out_path[0] == '\0') {
+            AVFSetError(error_out, @"capture session and output path are required");
+            return 0;
+        }
+
+        @try {
+            AVFStreamSession *stream = (__bridge AVFStreamSession *)session;
+            NSString *output_path = [NSString stringWithUTF8String:out_path];
+            return [stream captureFrameAtPath:output_path warmup:warmup_seconds error:error_out] ? 1 : 0;
+        } @catch (NSException *exception) {
+            AVFSetError(error_out, [NSString stringWithFormat:@"capture session frame: %@", exception.reason]);
             return 0;
         }
     }

--- a/internal/cli/ptz_test.go
+++ b/internal/cli/ptz_test.go
@@ -29,9 +29,11 @@ type fakePTZController struct {
 }
 
 type fakePTZSession struct {
-	closed bool
-	events *[]string
-	sleeps []time.Duration
+	closed         bool
+	events         *[]string
+	sleeps         []time.Duration
+	captures       []string
+	captureWarmups []time.Duration
 }
 
 func (s *fakePTZSession) Close() error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,6 +32,7 @@ func NewRootCommand(version string) *cobra.Command {
 		newDiscoverCmd(),
 		newDevicesCmd(),
 		newPTZCmd(),
+		newSweepCmd(),
 		newWatchCmd(),
 		newDoctorCmd(),
 		newVersionCmd(version),

--- a/internal/cli/sweep.go
+++ b/internal/cli/sweep.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/camsnap/internal/capture"
+	"github.com/steipete/camsnap/internal/uvc"
+)
+
+type sweepOptions struct {
+	from, to, tilt float64
+	steps          int
+	outDir         string
+	jsonOutput     bool
+	failFast       bool
+	capture        captureFlagValues
+	motion         ptzMotionOptions
+}
+
+type sweepAngle struct {
+	Degrees float64 `json:"degrees"`
+	Raw     int32   `json:"raw"`
+}
+
+type sweepPosition struct {
+	Pan  sweepAngle `json:"pan"`
+	Tilt sweepAngle `json:"tilt"`
+}
+
+type sweepStep struct {
+	Index             int           `json:"index"`
+	Requested         sweepPosition `json:"requested"`
+	Observed          sweepPosition `json:"observed"`
+	FramePath         string        `json:"frame_path"`
+	Verified          bool          `json:"verified"`
+	VerificationError string        `json:"verification_error,omitempty"`
+}
+
+type sweepManifest struct {
+	Device         localDevice `json:"device"`
+	FromDegrees    float64     `json:"from_degrees"`
+	ToDegrees      float64     `json:"to_degrees"`
+	TiltDegrees    float64     `json:"tilt_degrees"`
+	RequestedSteps int         `json:"requested_steps"`
+	Steps          []sweepStep `json:"steps"`
+}
+
+func newSweepCmd() *cobra.Command {
+	options := &sweepOptions{}
+	cmd := &cobra.Command{
+		Use:   "sweep [camera]",
+		Short: "Capture frames across a verified pan/tilt camera sweep",
+		Args:  cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			for _, flag := range []string{"from", "to"} {
+				if !cmd.Flags().Changed(flag) {
+					return fmt.Errorf("--%s is required", flag)
+				}
+			}
+			for flag, value := range map[string]float64{"from": options.from, "to": options.to, "tilt": options.tilt} {
+				if cmd.Flags().Changed(flag) && (math.IsNaN(value) || math.IsInf(value, 0)) {
+					return fmt.Errorf("--%s must be a finite number", flag)
+				}
+			}
+			if options.steps < 2 {
+				return fmt.Errorf("--steps must be at least 2")
+			}
+			if options.outDir == "" {
+				return fmt.Errorf("--out-dir is required")
+			}
+			return validatePTZTiming(&options.motion)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSweep(cmd, args, options)
+		},
+	}
+
+	cmd.Flags().Float64Var(&options.from, "from", 0, "Starting pan angle in degrees")
+	cmd.Flags().Float64Var(&options.to, "to", 0, "Ending pan angle in degrees")
+	cmd.Flags().IntVar(&options.steps, "steps", 0, "Number of evenly spaced capture positions (at least 2)")
+	cmd.Flags().StringVar(&options.outDir, "out-dir", "", "Directory for captured frames and manifest.json")
+	cmd.Flags().Float64Var(&options.tilt, "tilt", 0, "Fixed tilt angle in degrees (default: current camera tilt)")
+	cmd.Flags().BoolVar(&options.failFast, "fail-fast", false, "Stop after the first position verification failure")
+	cmd.Flags().BoolVar(&options.jsonOutput, "json", false, "Print the sweep manifest as JSON")
+	cmd.Flags().StringVar(&options.capture.device, "device", "", "Local video device index, ID, or name (default: default camera)")
+	cmd.Flags().IntVar(&options.capture.framerate, "framerate", 30, "Local capture framerate")
+	cmd.Flags().StringVar(&options.capture.videoSize, "video-size", "", "Local capture size (e.g., 1280x720)")
+	cmd.Flags().DurationVar(&options.capture.warmup, "warmup", time.Second, "One-time local camera auto-exposure warmup")
+	cmd.Flags().StringVar(&options.capture.localBackend, "local-backend", "", "Local capture backend (sweeps require native)")
+	addPTZTimingFlags(cmd, &options.motion)
+	return cmd
+}
+
+func runSweep(cmd *cobra.Command, args []string, options *sweepOptions) error {
+	camera, _, err := selectCaptureCameraWithDefault(cmd, args, "", options.capture.device, true)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(camera.Protocol, "local") {
+		return fmt.Errorf("camera %q is not a local camera and does not support absolute UVC pan/tilt control", camera.Name)
+	}
+	captureOptions, err := capture.Resolve(camera, options.capture.overrides(cmd))
+	if err != nil {
+		return err
+	}
+	if captureOptions.LocalBackend == capture.LocalBackendFFmpeg {
+		return fmt.Errorf("sweep requires the native local capture backend; ffmpeg cannot reuse the active camera stream")
+	}
+	if err := os.MkdirAll(options.outDir, 0o755); err != nil {
+		return fmt.Errorf("create sweep output directory %q: %w", options.outDir, err)
+	}
+
+	device, session, controller, err := openPTZ(cmd.Context(), captureOptions.Device)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = session.Close() }()
+	defer func() {
+		if controller != nil {
+			_ = controller.Close()
+		}
+	}()
+
+	captureSession, ok := session.(interface {
+		CaptureFrame(time.Duration, string) error
+	})
+	if !ok {
+		return fmt.Errorf("capture session for camera %q cannot save frames", device.Name)
+	}
+	capabilities := controller.Capabilities()
+	status, err := controller.Status()
+	if err != nil {
+		return fmt.Errorf("read PTZ status for camera %q: %w", device.Name, err)
+	}
+	if !capabilities.PanTiltAbsolute || status.Pan == nil || status.Tilt == nil {
+		return fmt.Errorf("camera %q does not support absolute UVC pan/tilt control", device.Name)
+	}
+
+	from := status.Pan.Range.Clamp(uvc.DegreesToArcsec(options.from))
+	to := status.Pan.Range.Clamp(uvc.DegreesToArcsec(options.to))
+	tilt := status.Tilt.Cur
+	if cmd.Flags().Changed("tilt") {
+		tilt = status.Tilt.Range.Clamp(uvc.DegreesToArcsec(options.tilt))
+	}
+	manifest := sweepManifest{
+		Device:         device,
+		FromDegrees:    uvc.ArcsecToDegrees(from),
+		ToDegrees:      uvc.ArcsecToDegrees(to),
+		TiltDegrees:    uvc.ArcsecToDegrees(tilt),
+		RequestedSteps: options.steps,
+		Steps:          make([]sweepStep, 0, options.steps),
+	}
+	failed := make([]string, 0)
+	indexWidth := max(3, len(strconv.Itoa(options.steps-1)))
+
+	for index := range options.steps {
+		if controller == nil {
+			controller, err = ptzOpenController(device.ID)
+			if err != nil {
+				return fmt.Errorf("open PTZ control connection for camera %q: %w", device.Name, err)
+			}
+		}
+		pan := int32(math.Round(float64(from) + float64(int64(to)-int64(from))*float64(index)/float64(options.steps-1)))
+		appliedPan, appliedTilt, setErr := controller.SetPanTilt(pan, tilt)
+		if setErr != nil {
+			return fmt.Errorf("set pan/tilt for camera %q at sweep step %d: %w", device.Name, index, setErr)
+		}
+		if err := controller.Close(); err != nil {
+			return fmt.Errorf("close PTZ control connection for camera %q before verification: %w", device.Name, err)
+		}
+		controller = nil
+
+		target := ptzTarget{pan: appliedPan, tilt: appliedTilt, checkPan: true, checkTilt: true}
+		observed, verificationErr := settlePTZMotion(cmd.Context(), ptzOpenController, device, target, &options.motion)
+		if observed.Pan == nil || observed.Tilt == nil {
+			if verificationErr != nil {
+				return verificationErr
+			}
+			return fmt.Errorf("read applied PTZ status for camera %q at sweep step %d: pan or tilt is unavailable", device.Name, index)
+		}
+
+		requested := sweepPosition{
+			Pan:  sweepAngle{Degrees: uvc.ArcsecToDegrees(appliedPan), Raw: appliedPan},
+			Tilt: sweepAngle{Degrees: uvc.ArcsecToDegrees(appliedTilt), Raw: appliedTilt},
+		}
+		framePath := filepath.Join(options.outDir, fmt.Sprintf("step-%0*d-pan-%+.3f.jpg", indexWidth, index, requested.Pan.Degrees))
+		warmup := time.Duration(0)
+		if index == 0 {
+			warmup = captureOptions.Warmup
+		}
+		if err := captureSession.CaptureFrame(warmup, framePath); err != nil {
+			return fmt.Errorf("capture sweep frame for camera %q at step %d: %w", device.Name, index, err)
+		}
+		step := sweepStep{
+			Index:     index,
+			Requested: requested,
+			Observed: sweepPosition{
+				Pan:  sweepAngle{Degrees: uvc.ArcsecToDegrees(observed.Pan.Cur), Raw: observed.Pan.Cur},
+				Tilt: sweepAngle{Degrees: uvc.ArcsecToDegrees(observed.Tilt.Cur), Raw: observed.Tilt.Cur},
+			},
+			FramePath: framePath,
+			Verified:  verificationErr == nil,
+		}
+		if verificationErr != nil {
+			step.VerificationError = verificationErr.Error()
+			failed = append(failed, strconv.Itoa(index))
+			cmd.PrintErrf("Sweep step %d verification failed: %v\n", index, verificationErr)
+		}
+		manifest.Steps = append(manifest.Steps, step)
+		if verificationErr != nil && options.failFast {
+			break
+		}
+	}
+
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode sweep manifest: %w", err)
+	}
+	data = append(data, '\n')
+	manifestPath := filepath.Join(options.outDir, "manifest.json")
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		return fmt.Errorf("write sweep manifest %q: %w", manifestPath, err)
+	}
+	if options.jsonOutput {
+		if _, err := cmd.OutOrStdout().Write(data); err != nil {
+			return fmt.Errorf("write sweep manifest: %w", err)
+		}
+	} else {
+		cmd.Printf("Captured %d sweep frames in %s (manifest: %s)\n", len(manifest.Steps), options.outDir, manifestPath)
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("sweep verification failed for steps %s", strings.Join(failed, ", "))
+	}
+	return nil
+}

--- a/internal/cli/sweep_test.go
+++ b/internal/cli/sweep_test.go
@@ -1,0 +1,356 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steipete/camsnap/internal/config"
+)
+
+func (s *fakePTZSession) CaptureFrame(warmup time.Duration, path string) error {
+	if s.closed {
+		return fmt.Errorf("capture session is closed")
+	}
+	s.captures = append(s.captures, path)
+	s.captureWarmups = append(s.captureWarmups, warmup)
+	if s.events != nil {
+		*s.events = append(*s.events, "capture:"+filepath.Base(path))
+	}
+	return os.WriteFile(path, []byte("fake JPEG"), 0o600)
+}
+
+func TestSweepKeepsOneSessionOpenAndCapturesVerifiedFrames(t *testing.T) {
+	var events []string
+	controllers := sweepControllers([]int32{-36000, 0, 36000}, nil, &events)
+	for index := 1; index < len(controllers); index += 2 {
+		controllers[index].status.Tilt.Cur = 18000
+	}
+	controllers[3].status.Pan.Cur = 900
+	session, restore := stubSweepBackend(t, controllers, &events)
+	defer restore()
+
+	outDir := filepath.Join(t.TempDir(), "frames")
+	var stdout, stderr bytes.Buffer
+	root := NewRootCommand("test")
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"sweep", "--device", "Link", "--from", "-10", "--to", "10", "--steps", "3",
+		"--tilt", "5", "--warmup", "250ms", "--out-dir", outDir, "--json",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+	if !session.closed {
+		t.Fatal("capture session was not closed")
+	}
+	if got := countSweepEvents(events, "session-open"); got != 1 {
+		t.Fatalf("capture session opens = %d, want 1: %v", got, events)
+	}
+	if len(events) == 0 || events[len(events)-1] != "session-close" {
+		t.Fatalf("capture session did not outlive every step: %v", events)
+	}
+	if got, want := session.captureWarmups, []time.Duration{250 * time.Millisecond, 0, 0}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("capture warmups = %v, want %v", got, want)
+	}
+	for index, raw := range []int32{-36000, 0, 36000} {
+		writer := controllers[index*2]
+		verifier := controllers[index*2+1]
+		if writer.setPan != raw || writer.setTilt != 18000 {
+			t.Errorf("step %d write = (%d, %d), want (%d, 18000)", index, writer.setPan, writer.setTilt, raw)
+		}
+		if !writer.closed || !verifier.closed || verifier.statusCalls < 2 {
+			t.Errorf("step %d controller lifecycle: writer closed=%t verifier closed=%t verifier reads=%d", index, writer.closed, verifier.closed, verifier.statusCalls)
+		}
+	}
+	assertSweepStepOrdering(t, events, 3)
+
+	manifestData, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(stdout.Bytes(), manifestData) {
+		t.Fatalf("JSON stdout differs from manifest file:\nstdout: %s\nmanifest: %s", stdout.String(), manifestData)
+	}
+	var manifest sweepManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Device.Name != "Insta360 Link" || manifest.FromDegrees != -10 || manifest.ToDegrees != 10 || manifest.TiltDegrees != 5 || manifest.RequestedSteps != 3 {
+		t.Fatalf("manifest metadata = %#v", manifest)
+	}
+	if len(manifest.Steps) != 3 {
+		t.Fatalf("manifest steps = %d, want 3", len(manifest.Steps))
+	}
+	for index, step := range manifest.Steps {
+		wantPan := int32(-36000 + index*36000)
+		wantObserved := wantPan
+		if index == 1 {
+			wantObserved = 900
+		}
+		if step.Index != index || step.Requested.Pan.Raw != wantPan || step.Observed.Pan.Raw != wantObserved {
+			t.Errorf("step %d pan = requested %#v, observed %#v", index, step.Requested.Pan, step.Observed.Pan)
+		}
+		if step.Requested.Tilt.Raw != 18000 || step.Observed.Tilt.Raw != 18000 || !step.Verified {
+			t.Errorf("step %d tilt/verification = %#v", index, step)
+		}
+		if filepath.Base(step.FramePath) != fmt.Sprintf("step-%03d-pan-%+.3f.jpg", index, step.Requested.Pan.Degrees) {
+			t.Errorf("step %d frame path = %q", index, step.FramePath)
+		}
+		if _, err := os.Stat(step.FramePath); err != nil {
+			t.Errorf("step %d frame is missing: %v", index, err)
+		}
+	}
+}
+
+func TestSweepVerificationFailureContinuesAndWritesManifest(t *testing.T) {
+	controllers := sweepControllers([]int32{-36000, 0, 36000}, map[int]int32{1: 18000}, nil)
+	session, restore := stubSweepBackend(t, controllers, nil)
+	defer restore()
+
+	outDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	root := NewRootCommand("test")
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"sweep", "--device", "Link", "--from", "-10", "--to", "10", "--steps", "3",
+		"--out-dir", outDir, "--json",
+	})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "sweep verification failed for steps 1") {
+		t.Fatalf("sweep error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Sweep step 1 verification failed") {
+		t.Fatalf("verification failure missing from stderr: %s", stderr.String())
+	}
+	if len(session.captures) != 3 {
+		t.Fatalf("captured frames = %d, want all 3", len(session.captures))
+	}
+
+	var manifest sweepManifest
+	if err := json.Unmarshal(stdout.Bytes(), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.Steps) != 3 || !manifest.Steps[0].Verified || manifest.Steps[1].Verified || !manifest.Steps[2].Verified {
+		t.Fatalf("verification results = %#v", manifest.Steps)
+	}
+	failed := manifest.Steps[1]
+	if failed.Requested.Pan.Raw != 0 || failed.Observed.Pan.Raw != 18000 || failed.VerificationError == "" {
+		t.Fatalf("failed step did not preserve the requested and observed positions: %#v", failed)
+	}
+	manifestData, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(manifestData, stdout.Bytes()) {
+		t.Fatal("failed sweep stdout differs from its saved manifest")
+	}
+}
+
+func TestSweepFailFastStopsAfterFailedStep(t *testing.T) {
+	controllers := sweepControllers([]int32{-36000, 0, 36000}, map[int]int32{1: 18000}, nil)
+	session, restore := stubSweepBackend(t, controllers, nil)
+	defer restore()
+
+	outDir := t.TempDir()
+	var stderr bytes.Buffer
+	root := NewRootCommand("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&stderr)
+	root.SetArgs([]string{
+		"sweep", "--device", "Link", "--from", "-10", "--to", "10", "--steps", "3",
+		"--out-dir", outDir, "--fail-fast",
+	})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "steps 1") {
+		t.Fatalf("sweep error = %v", err)
+	}
+	if len(session.captures) != 2 || controllers[4].panTiltSets != 0 {
+		t.Fatalf("fail-fast captured %d frames and moved the third writer %d times", len(session.captures), controllers[4].panTiltSets)
+	}
+	manifestData, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest sweepManifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.RequestedSteps != 3 || len(manifest.Steps) != 2 || manifest.Steps[1].Verified {
+		t.Fatalf("partial fail-fast manifest = %#v", manifest)
+	}
+}
+
+func TestSweepValidatesFlagsBeforeOpeningCamera(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing from", args: []string{"--to", "10", "--steps", "2", "--out-dir", "frames"}, want: "--from is required"},
+		{name: "missing to", args: []string{"--from", "-10", "--steps", "2", "--out-dir", "frames"}, want: "--to is required"},
+		{name: "too few steps", args: []string{"--from", "-10", "--to", "10", "--steps", "1", "--out-dir", "frames"}, want: "--steps must be at least 2"},
+		{name: "missing directory", args: []string{"--from", "-10", "--to", "10", "--steps", "2"}, want: "--out-dir is required"},
+		{name: "nonfinite from", args: []string{"--from", "NaN", "--to", "10", "--steps", "2", "--out-dir", "frames"}, want: "--from must be a finite number"},
+		{name: "nonfinite to", args: []string{"--from", "0", "--to", "+Inf", "--steps", "2", "--out-dir", "frames"}, want: "--to must be a finite number"},
+		{name: "nonfinite tilt", args: []string{"--from", "0", "--to", "10", "--tilt", "NaN", "--steps", "2", "--out-dir", "frames"}, want: "--tilt must be a finite number"},
+		{name: "invalid timing", args: []string{"--from", "0", "--to", "10", "--steps", "2", "--out-dir", "frames", "--settle", "5s", "--timeout", "5s"}, want: "--settle must be less than --timeout"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := NewRootCommand("test")
+			root.SetArgs(append([]string{"sweep", "--device", "Link"}, test.args...))
+			if err := root.Execute(); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Execute error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestSweepRejectsUnsupportedCameraAndBackend(t *testing.T) {
+	t.Run("no absolute pan tilt", func(t *testing.T) {
+		controller := newFakePTZController()
+		controller.capabilities.PanTiltAbsolute = false
+		session, restore := stubPTZBackendWithSession(t, controller)
+		defer restore()
+
+		root := NewRootCommand("test")
+		root.SetArgs([]string{"sweep", "--device", "Link", "--from", "0", "--to", "1", "--steps", "2", "--out-dir", t.TempDir()})
+		if err := root.Execute(); err == nil || !strings.Contains(err.Error(), `camera "Insta360 Link" does not support absolute UVC pan/tilt control`) {
+			t.Fatalf("unsupported camera error = %v", err)
+		}
+		if !session.closed {
+			t.Fatal("capture session remained open for an unsupported camera")
+		}
+	})
+
+	t.Run("ffmpeg backend", func(t *testing.T) {
+		root := NewRootCommand("test")
+		root.SetArgs([]string{"sweep", "--device", "Link", "--from", "0", "--to", "1", "--steps", "2", "--out-dir", t.TempDir(), "--local-backend", "ffmpeg"})
+		if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "sweep requires the native local capture backend") {
+			t.Fatalf("backend error = %v", err)
+		}
+	})
+
+	t.Run("output path is file", func(t *testing.T) {
+		outPath := filepath.Join(t.TempDir(), "existing")
+		if err := os.WriteFile(outPath, []byte("existing"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		root := NewRootCommand("test")
+		root.SetArgs([]string{"sweep", "--device", "Link", "--from", "0", "--to", "1", "--steps", "2", "--out-dir", outPath})
+		if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "create sweep output directory") {
+			t.Fatalf("output directory error = %v", err)
+		}
+	})
+}
+
+func TestSweepUsesSavedCameraAndClampsEndpoints(t *testing.T) {
+	controllers := sweepControllers([]int32{-324000, 324000}, nil, nil)
+	_, restore := stubSweepBackend(t, controllers, nil)
+	defer restore()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.Save(configPath, config.Config{Cameras: []config.Camera{{Name: "desk", Protocol: "local", Device: "Link"}}}); err != nil {
+		t.Fatal(err)
+	}
+	outDir := t.TempDir()
+	root := NewRootCommand("test")
+	root.SetOut(&bytes.Buffer{})
+	root.SetArgs([]string{"--config", configPath, "sweep", "desk", "--from", "-180", "--to", "180", "--steps", "2", "--out-dir", outDir})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(outDir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest sweepManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.FromDegrees != -90 || manifest.ToDegrees != 90 || manifest.TiltDegrees != -2 {
+		t.Fatalf("clamped sweep metadata = %#v", manifest)
+	}
+}
+
+func sweepControllers(pan []int32, failures map[int]int32, events *[]string) []*fakePTZController {
+	controllers := make([]*fakePTZController, 0, len(pan)*2)
+	for index, requested := range pan {
+		writer := newFakePTZController()
+		writer.events = events
+		verifier := newFakePTZController()
+		verifier.events = events
+		verifier.status.Pan.Cur = requested
+		if observed, failed := failures[index]; failed {
+			verifier.status.Pan.Cur = observed
+		}
+		controllers = append(controllers, writer, verifier)
+	}
+	return controllers
+}
+
+func stubSweepBackend(t *testing.T, controllers []*fakePTZController, events *[]string) (*fakePTZSession, func()) {
+	t.Helper()
+	session, restore := stubPTZBackendWithSession(t, controllers[0])
+	session.events = events
+	opens := 0
+	ptzOpenController = func(uniqueID string) (ptzController, error) {
+		if uniqueID != "camera-id" {
+			t.Fatalf("controller device ID = %q", uniqueID)
+		}
+		if events != nil {
+			*events = append(*events, "controller-open")
+		}
+		if opens >= len(controllers) {
+			t.Fatalf("unexpected controller open %d", opens)
+		}
+		controller := controllers[opens]
+		opens++
+		return controller, nil
+	}
+	return session, restore
+}
+
+func countSweepEvents(events []string, wanted string) int {
+	count := 0
+	for _, event := range events {
+		if event == wanted {
+			count++
+		}
+	}
+	return count
+}
+
+func assertSweepStepOrdering(t *testing.T, events []string, steps int) {
+	t.Helper()
+	var filtered []string
+	for _, event := range events {
+		if event == "set-pan-tilt" || event == "controller-close" || event == "status" || strings.HasPrefix(event, "capture:") {
+			filtered = append(filtered, event)
+		}
+	}
+	if len(filtered) == 0 || filtered[0] != "status" {
+		t.Fatalf("initial position was not read before moving: %v", events)
+	}
+	filtered = filtered[1:]
+	for index := range steps {
+		if len(filtered) < 6 || filtered[0] != "set-pan-tilt" || filtered[1] != "controller-close" || filtered[2] != "status" || filtered[3] != "status" || filtered[4] != "controller-close" || !strings.HasPrefix(filtered[5], "capture:") {
+			t.Fatalf("step %d did not move, close its writer, verify, and capture in order: %v", index, events)
+		}
+		filtered = filtered[6:]
+	}
+	if len(filtered) != 0 {
+		t.Fatalf("unexpected sweep control events: %v", filtered)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

Panning a gimbal camera across an arc and capturing at each stop currently means a hand-rolled shell loop. That loop has two problems beyond being tedious: it re-opens a capture session per frame, which is slow and lets the gimbal power down between steps, and it has no way to know whether the camera actually arrived at each position — so frames get labeled with the angle that was *requested* rather than the one that was reached.

## Why This Change Was Made

0.4.1 established that these cameras only service UVC controls while streaming, and that a position must be verified through a control connection that did not perform the write. A sweep is the case where that matters most: one missed step silently mislabels a frame, and nothing downstream can tell.

`camsnap sweep` holds a single AVFoundation session open for the entire arc and reuses `settlePTZMotion` at each position rather than reimplementing verification.

## User Impact

```
camsnap sweep --device 0 --from -120 --to 120 --steps 9 --tilt -18 --out-dir ./sweep
```

- One capture session for the whole sweep. Measured ~5x faster per frame than a loop that opens a session per step.
- Every frame is captured from a position confirmed through a fresh control connection.
- `manifest.json` records `requested` and `observed` pan/tilt per step (degrees and raw), the frame path, and `verified`. A partial sweep stays truthful rather than silently mislabeling frames.
- A step that fails verification is still captured and recorded; the sweep continues and exits non-zero at the end. `--fail-fast` stops at the first miss.
- `--local-backend ffmpeg` is rejected: it cannot capture from the already-open native session.

## Evidence

`make all`, `go build ./...`, `CGO_ENABLED=0 go test ./...`, `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...`, and `golangci-lint run ./...` under `GOOS=linux GOARCH=amd64` all pass.

Live run on an Insta360 Link 2 Pro: `--from -120 --to 120 --steps 9 --tilt -18` produced 9 frames in 29.9s, exit 0, with every step reporting `verified=true` and observed pan matching requested exactly at −120, −90, −60, −30, 0, 30, 60, 90, and 120 degrees. Each frame was checked by eye against a previously mapped reference sweep of the same room and matches its labeled angle.

Hermetic tests in `internal/cli/sweep_test.go` cover: the session is opened once and outlives every step, per-step move/verify/capture ordering, a failing step continuing by default with a non-zero exit, `--fail-fast` stopping early, and manifest contents matching observed values.

Frames are photographs of a private home and are not attached; they can be supplied privately on request.
