### PR TITLE
build: prefer Go 1.27.1 while retaining source minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.5.1 - Unreleased
+- Use Go 1.27.1 for preferred source, CI, and container builds while retaining the Go 1.27.0 source minimum.
 
 ## 0.5.0 - 2026-08-31
 - Add native single-session PTZ pan sweeps with verified frames, requested-versus-observed JSON manifests, and optional fail-fast handling.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.27-alpine AS build
+FROM golang:1.27.1-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/steipete/camsnap
 
 go 1.27.0
 
+toolchain go1.27.1
+
 require (
 	github.com/bluenviron/gortsplib/v5 v5.6.4
 	github.com/bluenviron/mediacommon/v2 v2.9.3


### PR DESCRIPTION
Go 1.27.1 is available, but source and CI builds still select 1.27.0. Prefer the patch release with a `toolchain go1.27.1` directive and align the Docker builder to `golang:1.27.1-alpine`. Keep `go 1.27.0` and the documented source minimum unchanged. Existing setup-go v7 workflows read the toolchain directive from `go.mod`.

The dependency audit found all declared Go modules and Action major versions current. No runtime module versions, CLI behavior, or release version changes are included.

Validation:

- `make all` and `go build ./...` passed with both `GOTOOLCHAIN=go1.27.0` and `GOTOOLCHAIN=go1.27.1`, using `GOMAXPROCS=2` and `GOFLAGS=-p=2`.
- `go mod tidy -diff` produced no changes; automatic toolchain selection reports Go 1.27.1.
- Developer ID–signed macOS CLI passed synthetic config add/list round trip, retained mode 0600, captured 160×120 JPEGs through both ffmpeg and gortsplib, and recorded a one-second H.264 clip. ffprobe verified the media.
- Docker image built successfully and passed `--version` and `--help` smoke checks.
- Independent Codex review of the complete candidate found no actionable P0–P2 findings.
